### PR TITLE
cli: add typpete as a type inference engine

### DIFF
--- a/tests/test_unsupported.py
+++ b/tests/test_unsupported.py
@@ -365,6 +365,7 @@ class CodeGeneratorTests(unittest.TestCase):
                 settings.rewriters,
                 settings.transformers,
                 settings.post_rewriters,
+                None,
             )
         except Exception as e:
             assert type(e) == expected_error


### PR DESCRIPTION
The default remains unchanged. So no tests should be affected.

Tested via: py2many.py --rust=1 --typpete=1 test.py

Related to: #96 