### PR TITLE
pycpp: Inline pycpp::sys

### DIFF
--- a/pycpp/plugins.py
+++ b/pycpp/plugins.py
@@ -145,9 +145,16 @@ DECORATOR_DISPATCH_TABLE = {ap_dataclass: CppTranspilerPlugins.visit_ap_dataclas
 
 CLASS_DISPATCH_TABLE = {ap_dataclass: CppTranspilerPlugins.visit_argparse_dataclass}
 
+
+def emit_argv(self, node, value, attr):
+    self._usings.add("<string>")
+    self._usings.add("<vector>")
+    return "std::vector<std::string>(argv, argv + argc)"
+
+
 ATTR_DISPATCH_TABLE = {
     "temp_file.name": lambda self, node, value, attr: f"{value}.path()",
-    "sys.argv": lambda self, node, value, attr: "pycpp::sys::argv",
+    "sys.argv": emit_argv,
 }
 
 FuncType = Union[Callable, str]

--- a/pycpp/plugins.py
+++ b/pycpp/plugins.py
@@ -148,8 +148,6 @@ CLASS_DISPATCH_TABLE = {ap_dataclass: CppTranspilerPlugins.visit_argparse_datacl
 ATTR_DISPATCH_TABLE = {
     "temp_file.name": lambda self, node, value, attr: f"{value}.path()",
     "sys.argv": lambda self, node, value, attr: "pycpp::sys::argv",
-    "math.pi": lambda self, node, value, attr: "pycpp::math::pi",
-    "math.e": lambda self, node, value, attr: "pycpp::math::e",
 }
 
 FuncType = Union[Callable, str]

--- a/pycpp/runtime/sys.h
+++ b/pycpp/runtime/sys.h
@@ -1,9 +1,0 @@
-#pragma once
-#include <vector>
-#include <string>
-
-namespace pycpp {
-namespace sys {
-static std::vector<std::string> argv;
-}
-}

--- a/pycpp/tests/test_transpiler.py
+++ b/pycpp/tests/test_transpiler.py
@@ -169,21 +169,3 @@ def test_map_function():
         return results;}
     """
     assert cpp == textwrap.dedent(expected)
-
-
-def test_normal_pdf():
-    source = parse(
-        "def pdf(x, mean, std_dev):",
-        "    term1 = 1.0 / ((2 * math.pi) ** 0.5)",
-        "    term2 = (math.e ** (-1.0 * (x-mean) ** 2.0 / 2.0",
-        "             * (std_dev ** 2.0)))",
-        "    return term1 * term2",
-    )
-    cpp = transpile(source)
-    expected = """\
-        template <typename T0, typename T1, typename T2>auto pdf(T0 x, T1 mean, T2 std_dev) {
-        auto term1 = 1.0 / (std::pow(2 * (pycpp::math::pi), 0.5));
-        auto term2 = std::pow(pycpp::math::e, (((-1.0) * (std::pow(x - mean, 2.0))) / 2.0) * (std::pow(std_dev, 2.0)));
-        return term1 * term2;}
-    """
-    assert cpp == parse(textwrap.dedent(expected))

--- a/pycpp/tests/test_transpiler.py
+++ b/pycpp/tests/test_transpiler.py
@@ -85,8 +85,7 @@ def test_print_program_args():
     # is not the main py2many wrapper, and notably doesnt use PythonMainRewriter.
     assert cpp == parse(
         "void main() {",
-        "pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);",
-        "for(auto arg : pycpp::sys::argv) {",
+        "for(auto arg : std::vector<std::string>(argv, argv + argc)) {",
         "std::cout << arg;",
         "std::cout << std::endl;",
         "}}",

--- a/pycpp/transpiler.py
+++ b/pycpp/transpiler.py
@@ -144,7 +144,6 @@ class CppTranspiler(CLikeTranspiler):
 
     def headers(self, meta: InferMeta):
         lint_exception = self._get_nolint_suffix()
-        self._headers.append('#include "pycpp/runtime/sys.h"')
         if self.use_catch_test_cases:
             self._headers.append("#include <catch2/catch_test_macros.hpp>")
         if meta.has_fixed_width_ints:
@@ -194,10 +193,6 @@ class CppTranspiler(CLikeTranspiler):
             template = f"template <{typedecls_str}>"
 
         if is_python_main:
-            body = (
-                "pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);\n"
-                + body
-            )
             template = ""
 
         if not is_void_function(node):
@@ -330,6 +325,7 @@ class CppTranspiler(CLikeTranspiler):
         fields = "\n".join([f for f in fields])
         definitions = "\n".join([d for d in definitions])
         lint_exception = self._get_nolint_suffix("runtime/explicit")
+        self._usings.add("<string>")
         return textwrap.dedent(
             f"""\
             class {node.name} : public std::string {{

--- a/tests/dir_cases/test1-cpp-expected/bar.cpp
+++ b/tests/dir_cases/test1-cpp-expected/bar.cpp
@@ -1,2 +1,1 @@
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
 inline int bar1() { return 0; }

--- a/tests/dir_cases/test1-cpp-expected/baz.cpp
+++ b/tests/dir_cases/test1-cpp-expected/baz.cpp
@@ -1,2 +1,1 @@
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
 inline std::string baz1() { return std::string{"foo"}; }

--- a/tests/dir_cases/test1-cpp-expected/foo.cpp
+++ b/tests/dir_cases/test1-cpp-expected/foo.cpp
@@ -2,9 +2,7 @@
 
 #include "bar.h"
 #include "baz.h"
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
 int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
   int x = bar1();
   std::string y = baz1();
   assert(x == 0);

--- a/tests/expected/assert.cpp
+++ b/tests/expected/assert.cpp
@@ -1,14 +1,11 @@
 #include <cassert>   // NOLINT(build/include_order)
 #include <iostream>  // NOLINT(build/include_order)
-
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
 inline void compare_assert(int a, int b) {
   assert(a == b);
   assert(!(0 == 1));
 }
 
 int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
   assert(true);
   assert(!(false));
   compare_assert(1, 1);

--- a/tests/expected/binit.cpp
+++ b/tests/expected/binit.cpp
@@ -2,8 +2,6 @@
 #include <iostream>  // NOLINT(build/include_order)
 #include <vector>    // NOLINT(build/include_order)
 
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
-
 inline int bisect_right(std::vector<int>& data, int item) {
   int low = 0;
   int high = static_cast<int>(static_cast<int>(data.size()));
@@ -31,7 +29,6 @@ inline std::vector<int> bin_it(std::vector<int>& limits,
 }
 
 int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
   std::vector<int> limits = {23, 37, 43, 53, 67, 83};
   std::vector<int> data = {95, 21, 94, 12, 99, 4,  70, 75, 83, 93, 52, 80, 57,
                            5,  53, 86, 65, 17, 92, 83, 71, 61, 54, 58, 47, 16,

--- a/tests/expected/bitops.cpp
+++ b/tests/expected/bitops.cpp
@@ -2,8 +2,6 @@
 #include <iostream>  // NOLINT(build/include_order)
 #include <vector>    // NOLINT(build/include_order)
 
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
-
 inline void main_func() {
   std::vector<bool> ands = {};
   std::vector<bool> ors = {};
@@ -31,7 +29,4 @@ inline void main_func() {
   std::cout << std::endl;
 }
 
-int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
-  main_func();
-}
+int main(int argc, char** argv) { main_func(); }

--- a/tests/expected/bubble_sort.cpp
+++ b/tests/expected/bubble_sort.cpp
@@ -4,8 +4,6 @@
 #include <tuple>                   // NOLINT(build/include_order)
 #include <vector>                  // NOLINT(build/include_order)
 
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
-
 inline std::vector<int> bubble_sort(std::vector<int>& seq) {
   auto L = static_cast<int>(seq.size());
   for (auto _ : iter::range(L)) {
@@ -19,7 +17,6 @@ inline std::vector<int> bubble_sort(std::vector<int>& seq) {
 }
 
 int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
   std::vector<int> unsorted = {14, 11, 19, 5, 16, 10, 19, 12, 5, 12};
   std::vector<int> expected = {5, 5, 10, 11, 12, 12, 14, 16, 19, 19};
   assert(bubble_sort(unsorted) == expected);

--- a/tests/expected/built_ins.cpp
+++ b/tests/expected/built_ins.cpp
@@ -1,7 +1,5 @@
 #include <cassert>   // NOLINT(build/include_order)
 #include <iostream>  // NOLINT(build/include_order)
-
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
 inline void default_builtins() {
   std::string a = "";
   bool b = false;
@@ -14,7 +12,6 @@ inline void default_builtins() {
 }
 
 int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
   int a = std::max(1, 2);
   std::cout << a;
   std::cout << std::endl;

--- a/tests/expected/classes.cpp
+++ b/tests/expected/classes.cpp
@@ -1,7 +1,5 @@
 #include <cassert>   // NOLINT(build/include_order)
 #include <iostream>  // NOLINT(build/include_order)
-
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
 class Foo {
  public:
   inline int bar() { return this->baz(); }
@@ -10,7 +8,6 @@ class Foo {
 };
 
 int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
   Foo f = Foo();
   auto b = f.bar();
   std::cout << b;

--- a/tests/expected/cls.cpp
+++ b/tests/expected/cls.cpp
@@ -1,13 +1,10 @@
 #include <iostream>  // NOLINT(build/include_order)
-
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
 class Foo {
  public:
   inline std::string bar() { return std::string{"a"}; }
 };
 
 int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
   Foo f = Foo();
   auto b = f.bar();
   std::cout << b;

--- a/tests/expected/comb_sort.cpp
+++ b/tests/expected/comb_sort.cpp
@@ -6,8 +6,6 @@
 #include <tuple>                   // NOLINT(build/include_order)
 #include <vector>                  // NOLINT(build/include_order)
 
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
-
 inline std::vector<int> comb_sort(std::vector<int>& seq) {
   auto gap = static_cast<int>(seq.size());
   bool swap = true;
@@ -25,7 +23,6 @@ inline std::vector<int> comb_sort(std::vector<int>& seq) {
 }
 
 int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
   std::vector<int> unsorted = {14, 11, 19, 5, 16, 10, 19, 12, 5, 12};
   std::vector<int> expected = {5, 5, 10, 11, 12, 12, 14, 16, 19, 19};
   assert(comb_sort(unsorted) == expected);

--- a/tests/expected/comment_unsupported.cpp
+++ b/tests/expected/comment_unsupported.cpp
@@ -1,6 +1,4 @@
 #include <iostream>  // NOLINT(build/include_order)
-
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
 inline void do_unsupported() {
   int a = 1;
   /* dict comprehension (key + 1, value + 1) unimplemented on line 9:4 */;
@@ -9,7 +7,4 @@ inline void do_unsupported() {
   std::cout << std::endl;
 }
 
-int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
-  do_unsupported();
-}
+int main(int argc, char** argv) { do_unsupported(); }

--- a/tests/expected/coverage.cpp
+++ b/tests/expected/coverage.cpp
@@ -5,8 +5,6 @@
 #include <map>                     // NOLINT(build/include_order)
 #include <vector>                  // NOLINT(build/include_order)
 
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
-
 inline void inline_pass() {
 /* pass */}
 
@@ -115,7 +113,4 @@ inline void show() {
   int _c2 = 3;
 }
 
-int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
-  show();
-}
+int main(int argc, char** argv) { show(); }

--- a/tests/expected/fib.cpp
+++ b/tests/expected/fib.cpp
@@ -1,6 +1,4 @@
 #include <iostream>  // NOLINT(build/include_order)
-
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
 inline int fib(int i) {
   if (i == 0 || i == 1) {
     return 1;
@@ -9,7 +7,6 @@ inline int fib(int i) {
 }
 
 int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
   std::cout << fib(5);
   std::cout << std::endl;
 }

--- a/tests/expected/global.cpp
+++ b/tests/expected/global.cpp
@@ -1,8 +1,6 @@
 #include <algorithm>  // NOLINT(build/include_order)
 #include <iostream>   // NOLINT(build/include_order)
 #include <vector>     // NOLINT(build/include_order)
-
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
 int code_0 = 0;
 int code_1 = 1;
 std::vector<int> l_a = {code_0, code_1};
@@ -10,7 +8,6 @@ std::string code_a = std::string{"a"};  // NOLINT(runtime/string)
 std::string code_b = std::string{"b"};  // NOLINT(runtime/string)
 std::vector<std::string> l_b = {code_a, code_b};
 int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
   for (auto i : l_a) {
     std::cout << i;
     std::cout << std::endl;

--- a/tests/expected/global2.cpp
+++ b/tests/expected/global2.cpp
@@ -3,8 +3,6 @@
 #include <iostream>   // NOLINT(build/include_order)
 #include <map>        // NOLINT(build/include_order)
 #include <set>        // NOLINT(build/include_order)
-
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
 int code_0 = 0;
 int code_1 = 1;
 std::string code_a = std::string{"a"};  // NOLINT(runtime/string)
@@ -12,7 +10,6 @@ std::string code_b = std::string{"b"};  // NOLINT(runtime/string)
 std::set<std::string> l_b = std::set<std::string>{code_a};
 std::map<std::string, int> l_c = std::map<std::string, int>{{code_b, code_0}};
 int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
   assert((std::find(l_b.begin(), l_b.end(), std::string{"a"}) != l_b.end()));
   std::cout << std::string{"OK"};
   std::cout << std::endl;

--- a/tests/expected/hello_world.cpp
+++ b/tests/expected/hello_world.cpp
@@ -1,8 +1,5 @@
 #include <iostream>  // NOLINT(build/include_order)
-
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
 int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
   std::cout << std::string{"Hello world!"};
   std::cout << std::endl;
   std::cout << std::string{"Hello"};

--- a/tests/expected/import_tests.cpp
+++ b/tests/expected/import_tests.cpp
@@ -2,15 +2,12 @@
 #include <iostream>  // NOLINT(build/include_order)
 #include <vector>    // NOLINT(build/include_order)
 
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
-
 inline int test() {
   std::vector<int> a = {1, 2, 3};
   return a[1];
 }
 
 int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
   int b = test();
   assert(b == 2);
   std::cout << std::string{"OK"};

--- a/tests/expected/infer.cpp
+++ b/tests/expected/infer.cpp
@@ -1,7 +1,5 @@
 #include <cassert>   // NOLINT(build/include_order)
 #include <iostream>  // NOLINT(build/include_order)
-
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
 inline void foo() {
   int a = 10;
   int b = a;
@@ -10,7 +8,4 @@ inline void foo() {
   std::cout << std::endl;
 }
 
-int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
-  foo();
-}
+int main(int argc, char** argv) { foo(); }

--- a/tests/expected/infer_ops.cpp
+++ b/tests/expected/infer_ops.cpp
@@ -1,8 +1,6 @@
 #include <cassert>   // NOLINT(build/include_order)
 #include <iostream>  // NOLINT(build/include_order)
 
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
-
 inline void foo() {
   int a = 10;
   int b = 20;
@@ -51,7 +49,6 @@ inline void show() {
 }
 
 int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
   foo();
   show();
 }

--- a/tests/expected/int_enum.cpp
+++ b/tests/expected/int_enum.cpp
@@ -2,8 +2,6 @@
 #include <iostream>  // NOLINT(build/include_order)
 #include <map>       // NOLINT(build/include_order)
 
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
-
 enum Colors : int {
   RED = 0,
   GREEN = 1,
@@ -40,7 +38,4 @@ inline void show() {
   assert(static_cast<int>(color_map.size()) != 0);
 }
 
-int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
-  show();
-}
+int main(int argc, char** argv) { show(); }

--- a/tests/expected/lambda.cpp
+++ b/tests/expected/lambda.cpp
@@ -1,14 +1,9 @@
 #include <iostream>  // NOLINT(build/include_order)
 
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
-
 inline void show() {
   auto myfunc = [](auto x, auto y) { return x + y; };
   std::cout << myfunc(1, 2);
   std::cout << std::endl;
 }
 
-int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
-  show();
-}
+int main(int argc, char** argv) { show(); }

--- a/tests/expected/loop.cpp
+++ b/tests/expected/loop.cpp
@@ -1,7 +1,5 @@
 #include <cppitertools/range.hpp>  // NOLINT(build/include_order)
 #include <iostream>                // NOLINT(build/include_order)
-
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
 inline void for_with_break() {
   for (auto i : iter::range(4)) {
     if (i == 2) {
@@ -54,7 +52,6 @@ inline void while_with_continue() {
 }
 
 int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
   for_with_break();
   for_with_continue();
   while_with_break();

--- a/tests/expected/math_func.cpp
+++ b/tests/expected/math_func.cpp
@@ -1,14 +1,9 @@
 #include <cmath>     // NOLINT(build/include_order)
 #include <iostream>  // NOLINT(build/include_order)
-
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
 inline void main_func() {
   int a = std::pow(2, 4);
   std::cout << a;
   std::cout << std::endl;
 }
 
-int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
-  main_func();
-}
+int main(int argc, char** argv) { main_func(); }

--- a/tests/expected/nested_dict.cpp
+++ b/tests/expected/nested_dict.cpp
@@ -2,8 +2,6 @@
 #include <iostream>   // NOLINT(build/include_order)
 #include <map>        // NOLINT(build/include_order)
 #include <vector>     // NOLINT(build/include_order)
-
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
 inline bool nested_containers() {
   std::map<std::string, std::vector<int>> CODES =
       std::map<std::string, std::vector<int>>{{std::string{"KEY"}, {1, 3}}};
@@ -13,7 +11,6 @@ inline bool nested_containers() {
 }
 
 int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
   if (nested_containers()) {
     std::cout << std::string{"OK"};
     std::cout << std::endl;

--- a/tests/expected/print.cpp
+++ b/tests/expected/print.cpp
@@ -1,6 +1,4 @@
 #include <iostream>  // NOLINT(build/include_order)
-
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
 inline void show() {
   std::cout << std::string{"b"};
   std::cout << std::endl;
@@ -19,7 +17,4 @@ inline void show() {
   std::cout << std::endl;
 }
 
-int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
-  show();
-}
+int main(int argc, char** argv) { show(); }

--- a/tests/expected/rect.cpp
+++ b/tests/expected/rect.cpp
@@ -1,7 +1,5 @@
 #include <cassert>   // NOLINT(build/include_order)
 #include <iostream>  // NOLINT(build/include_order)
-
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
 /* This file implements a rectangle class  */
 
 class Rectangle {
@@ -27,7 +25,4 @@ inline void show() {
   std::cout << std::endl;
 }
 
-int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
-  show();
-}
+int main(int argc, char** argv) { show(); }

--- a/tests/expected/str_enum.cpp
+++ b/tests/expected/str_enum.cpp
@@ -1,7 +1,6 @@
 #include <iostream>  // NOLINT(build/include_order)
 #include <map>       // NOLINT(build/include_order)
-
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
+#include <string>    // NOLINT(build/include_order)
 
 class Colors : public std::string {
  public:
@@ -32,7 +31,4 @@ inline void show() {
   std::cout << std::endl;
 }
 
-int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
-  show();
-}
+int main(int argc, char** argv) { show(); }

--- a/tests/expected/sys_argv.cpp
+++ b/tests/expected/sys_argv.cpp
@@ -1,11 +1,10 @@
 #include <cassert>   // NOLINT(build/include_order)
 #include <iostream>  // NOLINT(build/include_order)
-
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
+#include <string>    // NOLINT(build/include_order)
+#include <vector>    // NOLINT(build/include_order)
 
 int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
-  std::vector<std::string> a = pycpp::sys::argv;
+  std::vector<std::string> a = std::vector<std::string>(argv, argv + argc);
   std::string cmd = a[0];
   if (cmd == std::string{"dart"}) {
     /* pass */

--- a/tests/expected/sys_exit.cpp
+++ b/tests/expected/sys_exit.cpp
@@ -1,9 +1,6 @@
 #include <iostream>  // NOLINT(build/include_order)
 
-#include "pycpp/runtime/sys.h"  // NOLINT(build/include_order)
-
 int main(int argc, char** argv) {
-  pycpp::sys::argv = std::vector<std::string>(argv, argv + argc);
   std::cout << std::string{"OK"};
   std::cout << std::endl;
   exit(1);


### PR DESCRIPTION
This adds a restriction that `sys.argv` can only be accessed from inside the `main` where `argv` is in scope, however that limitation already exists in other language targets.  It isn't great, but it does re-position pycpp to only depend on conan packages; i.e. no includes of its own.  Any future enhancements now need to rely on features available in conan packages.