### PR TITLE
Add missing generic_visit()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,11 @@ test = true
 path = "tests/expected/hello_world.rs"
 
 [[bin]]
+name = "ifexp"
+test = true
+path = "tests/expected/ifexp.rs"
+
+[[bin]]
 name = "infer"
 test = true
 path = "tests/expected/infer.rs"

--- a/py2many/context.py
+++ b/py2many/context.py
@@ -141,6 +141,7 @@ class VariableTransformer(ast.NodeTransformer, ScopeMixin):
             if isinstance(target, ast.Name):
                 target.assigned_from = node
                 self.scope.vars.append(target)
+        self.generic_visit(node)
         return node
 
     def visit_AnnAssign(self, node):
@@ -148,6 +149,7 @@ class VariableTransformer(ast.NodeTransformer, ScopeMixin):
         if isinstance(target, ast.Name):
             target.assigned_from = node
             self.scope.vars.append(target)
+        self.generic_visit(node)
         return node
 
     def visit_AugAssign(self, node):
@@ -155,6 +157,7 @@ class VariableTransformer(ast.NodeTransformer, ScopeMixin):
         if isinstance(target, ast.Name):
             target.assigned_from = node
             self.scope.vars.append(target)
+        self.generic_visit(node)
         return node
 
 

--- a/tests/cases/ifexp.py
+++ b/tests/cases/ifexp.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+
+def show():
+    # ifexp
+    a = 1
+    b = 2 if a in [2, 3] else 3
+    print(b)
+
+
+if __name__ == "__main__":
+    show()

--- a/tests/expected/ifexp.cpp
+++ b/tests/expected/ifexp.cpp
@@ -1,0 +1,16 @@
+#include <algorithm>  // NOLINT(build/include_order)
+#include <iostream>   // NOLINT(build/include_order)
+#include <vector>     // NOLINT(build/include_order)
+inline void show() {
+  int a = 1;
+  auto b = (({
+    std::vector<int> __tmp1 = {2, 3};
+    (std::find(__tmp1.begin(), __tmp1.end(), a) != __tmp1.end());
+  })
+                ? ({ 2; })
+                : ({ 3; }));
+  std::cout << b;
+  std::cout << std::endl;
+}
+
+int main(int argc, char** argv) { show(); }

--- a/tests/expected/ifexp.nim
+++ b/tests/expected/ifexp.nim
@@ -1,0 +1,9 @@
+proc show() =
+  let a = 1
+  let b = if a in @[2, 3]: 2 else: 3
+  echo b
+
+proc main() =
+  show()
+
+main()

--- a/tests/expected/ifexp.py
+++ b/tests/expected/ifexp.py
@@ -1,0 +1,14 @@
+from typing import Callable, Dict, List, Set, Optional
+from ctypes import c_int8 as i8, c_int16 as i16, c_int32 as i32, c_int64 as i64
+from ctypes import c_uint8 as u8, c_uint16 as u16, c_uint32 as u32, c_uint64 as u64
+import sys
+
+
+def show():
+    a: int = 1
+    b = 2 if a in [2, 3] else 3
+    print(b)
+
+
+if __name__ == "__main__":
+    show()

--- a/tests/expected/ifexp.rs
+++ b/tests/expected/ifexp.rs
@@ -1,0 +1,42 @@
+//! ```cargo
+//! [package]
+//! edition = "2018"
+//! [dependencies]
+//! anyhow = "*"
+//! ```
+
+#![allow(clippy::collapsible_else_if)]
+#![allow(clippy::double_parens)] // https://github.com/adsharma/py2many/issues/17
+#![allow(clippy::map_identity)]
+#![allow(clippy::needless_return)]
+#![allow(clippy::print_literal)]
+#![allow(clippy::ptr_arg)]
+#![allow(clippy::redundant_static_lifetimes)] // https://github.com/adsharma/py2many/issues/266
+#![allow(clippy::unnecessary_cast)]
+#![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::useless_vec)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(unused_imports)]
+#![allow(unused_mut)]
+#![allow(unused_parens)]
+
+extern crate anyhow;
+use anyhow::Result;
+use std::collections;
+
+pub fn show() {
+    let a: i32 = 1;
+    let b = if vec![2, 3].iter().any(|&x| x == a) {
+        2
+    } else {
+        3
+    };
+    println!("{}", b);
+}
+
+pub fn main() -> Result<()> {
+    show();
+    Ok(())
+}


### PR DESCRIPTION
Without this, some assignment statements are not properly annotated with variable context (e.g. which variables are assigned inside the body).

We were hitting this case after a rewrite.

Fixes: https://github.com/py2many/py2many/issues/527