### PR TITLE
Improve indexing translation

### DIFF
--- a/py2many/cli.py
+++ b/py2many/cli.py
@@ -26,6 +26,7 @@ from .toposort_modules import toposort
 from py2many.rewriters import (
     ComplexDestructuringRewriter,
     FStringJoinRewriter,
+    LoopElseRewriter,
     PythonMainRewriter,
     DocStringToCommentRewriter,
     PrintBoolRewriter,
@@ -94,6 +95,9 @@ def _transpile(
         StrStrRewriter(language),
         UnpackScopeRewriter(language),
     ]
+    if settings.ext != ".py":
+        generic_post_rewriters.append(LoopElseRewriter(language))
+
     rewriters = generic_rewriters + rewriters
     post_rewriters = generic_post_rewriters + post_rewriters
     outputs = {}

--- a/py2many/tracer.py
+++ b/py2many/tracer.py
@@ -71,6 +71,42 @@ def is_list(node):
         return False
 
 
+# Searches for the first node of type node_type using
+# the given scope (search in reverse order)
+def find_node_by_type(node_type, scopes):
+    c_node = None
+    for i in range(len(scopes) - 1, -1, -1):
+        sc = scopes[i]
+        if isinstance(sc, node_type):
+            c_node = sc
+            break
+        if hasattr(sc, "body"):
+            c_node = find_in_body(sc.body, (lambda x: isinstance(x, node_type)))
+            if c_node is not None:
+                break
+    return c_node
+
+
+# Finds a node in the given body if it satisfies fn
+def find_in_body(body, fn):
+    for i in range(len(body) - 1, -1, -1):
+        node = body[i]
+        if fn(node):
+            return node
+        elif isinstance(node, ast.Expr) and hasattr(node, "value") and fn(node.value):
+            return node.value
+        elif hasattr(node, "iter") and fn(node.iter):
+            return node.iter
+        elif hasattr(node, "test") and fn(node.test):
+            return node.test
+        elif hasattr(node, "body"):
+            ret = find_in_body(node.body, fn)
+            if ret:
+                return ret
+
+    return None
+
+
 def value_expr(node):
     """
     Follow all assignments down the rabbit hole in order to find

--- a/tests/cases/loop.py
+++ b/tests/cases/loop.py
@@ -41,6 +41,6 @@ if __name__ == "__main__":
     for_with_break()
     for_with_continue()
     # https://github.com/adsharma/py2many/issues/415
-    # for_with_else()
+    for_with_else()
     while_with_break()
     while_with_continue()

--- a/tests/expected/loop.cpp
+++ b/tests/expected/loop.cpp
@@ -21,8 +21,13 @@ inline void for_with_continue() {
 }
 
 inline void for_with_else() {
+  bool has_break = false;
   for (auto i : iter::range(4)) {
     std::cout << i;
+    std::cout << std::endl;
+  }
+  if (has_break != true) {
+    std::cout << std::string{"OK"};
     std::cout << std::endl;
   }
 }
@@ -54,6 +59,7 @@ inline void while_with_continue() {
 int main(int argc, char** argv) {
   for_with_break();
   for_with_continue();
+  for_with_else();
   while_with_break();
   while_with_continue();
 }

--- a/tests/expected/loop.dart
+++ b/tests/expected/loop.dart
@@ -20,8 +20,13 @@ for_with_continue() {
 }
 
 for_with_else() {
+  final bool has_break = false;
   for (final i in ([for (var i = 0; i < 4; i += 1) i])) {
     print(sprintf("%s", [i]));
+  }
+
+  if (has_break != true) {
+    print(sprintf("%s", ["OK"]));
   }
 }
 
@@ -51,6 +56,7 @@ while_with_continue() {
 main(List<String> argv) {
   for_with_break();
   for_with_continue();
+  for_with_else();
   while_with_break();
   while_with_continue();
 }

--- a/tests/expected/loop.go
+++ b/tests/expected/loop.go
@@ -24,8 +24,12 @@ func ForWithContinue() {
 }
 
 func ForWithElse() {
+	var has_break bool = false
 	for _, i := range iter.NewIntSeq(iter.Start(0), iter.Stop(4)).All() {
 		fmt.Printf("%v\n", i)
+	}
+	if has_break != true {
+		fmt.Printf("%v\n", "OK")
 	}
 }
 
@@ -54,6 +58,7 @@ func WhileWithContinue() {
 func main() {
 	ForWithBreak()
 	ForWithContinue()
+	ForWithElse()
 	WhileWithBreak()
 	WhileWithContinue()
 }

--- a/tests/expected/loop.jl
+++ b/tests/expected/loop.jl
@@ -17,8 +17,12 @@ function for_with_continue()
 end
 
 function for_with_else()
+    has_break = false
     for i = 0:4-1
         println(join([i], " "))
+    end
+    if has_break != true
+        println(join(["OK"], " "))
     end
 end
 
@@ -47,6 +51,7 @@ end
 function main()
     for_with_break()
     for_with_continue()
+    for_with_else()
     while_with_break()
     while_with_continue()
 end

--- a/tests/expected/loop.kt
+++ b/tests/expected/loop.kt
@@ -15,8 +15,12 @@ fun for_with_continue() {
     } }
 
 fun for_with_else() {
+    val has_break = false
     for (i in (0..4 - 1)) {
         println("$i")
+    }
+    if (has_break != true) {
+        println("OK")
     } }
 
 fun while_with_break() {
@@ -42,5 +46,6 @@ fun while_with_continue() {
 fun main(argv: Array<String>) {
     for_with_break()
     for_with_continue()
+    for_with_else()
     while_with_break()
     while_with_continue() }

--- a/tests/expected/loop.nim
+++ b/tests/expected/loop.nim
@@ -13,8 +13,12 @@ proc for_with_continue() =
     echo i
 
 proc for_with_else() =
+  let has_break = false
   for i in (0..4 - 1):
     echo i
+  if has_break != true:
+    echo "OK"
+
 
 proc while_with_break() =
   var i = 0
@@ -37,6 +41,7 @@ proc while_with_continue() =
 proc main() =
   for_with_break()
   for_with_continue()
+  for_with_else()
   while_with_break()
   while_with_continue()
 

--- a/tests/expected/loop.py
+++ b/tests/expected/loop.py
@@ -46,5 +46,6 @@ def while_with_continue():
 if __name__ == "__main__":
     for_with_break()
     for_with_continue()
+    for_with_else()
     while_with_break()
     while_with_continue()

--- a/tests/expected/loop.rs
+++ b/tests/expected/loop.rs
@@ -44,8 +44,12 @@ pub fn for_with_continue() {
 }
 
 pub fn for_with_else() {
+    let has_break: bool = false;
     for i in (0..4) {
         println!("{}", i);
+    }
+    if has_break != true {
+        println!("{}", "OK");
     }
 }
 
@@ -74,6 +78,7 @@ pub fn while_with_continue() {
 pub fn main() -> Result<()> {
     for_with_break();
     for_with_continue();
+    for_with_else();
     while_with_break();
     while_with_continue();
     Ok(())


### PR DESCRIPTION
This aims to remove the redundant code produced by the initial indexing translation mechanism. This includes redundant operations, such as `-1+1`. This is a proposed fix for #529.
Furthermore, it also introduces some heuristics to translate negative indexing to Julia.
