### PR TITLE
Use jgo for kscript

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: actions/setup-java@v3
-        if: ${{ matrix.os != 'macos-12' && (!env.FOCUS || env.FOCUS == 'kotlin') }}
+        if: ${{ !env.FOCUS || env.FOCUS == 'kotlin' }}
         with:
           distribution: adopt
           java-version: 15
@@ -55,8 +55,14 @@ jobs:
 
       - uses: julia-actions/setup-julia@v1
         if: ${{ !env.FOCUS || env.FOCUS == 'julia' }}
+
       - uses: fwilhe2/setup-kotlin@main
-        if: ${{ matrix.os != 'macos-12' && (!env.FOCUS || env.FOCUS == 'kotlin') }}
+        if: ${{ !env.FOCUS || env.FOCUS == 'kotlin' }}
+      - name: Set KOTLIN_HOME
+        if: ${{ !env.FOCUS || env.FOCUS == 'kotlin' }}
+        shell: bash
+        run: |
+          echo KOTLIN_HOME=$(kotlin -e 'System.getProperty("kotlin.home")') >> $GITHUB_ENV
 
       - uses: jiro4989/setup-nim-action@v1
         if: ${{ !env.FOCUS || env.FOCUS == 'nim' }}
@@ -118,13 +124,11 @@ jobs:
               pip3 install conan
               echo "CXX=clang++-14" >> $GITHUB_ENV
           elif [ "$RUNNER_OS" == "macOS" ]; then
-              brew tap holgerbrandl/tap https://github.com/holgerbrandl/homebrew-tap
               brew install \
                   astyle \
                   catch2 \
                   clang-format \
                   conan \
-                  kscript \
                   z3 \
                 && true
               # brew's vlang 0.2.4 is too old, and has no @head
@@ -139,7 +143,6 @@ jobs:
                 && true
               echo "C:/Program Files/Conan/conan/" >> $GITHUB_PATH
           fi
-          echo "WHICH_KSCRIPT=$(which kscript 2>/dev/null)" >> $GITHUB_ENV
           echo "WHICH_V=$(which v 2>/dev/null)" >> $GITHUB_ENV
 
       - name: Install C++ packages
@@ -160,14 +163,6 @@ jobs:
         shell: bash
         run: |
           v install div72.vexc
-
-      - name: Install kscript (using sdkman)
-        if: ${{ !env.WHICH_KSCRIPT && matrix.os == 'ubuntu-22.04' && (!env.FOCUS || env.FOCUS == 'kotlin') }}
-        shell: bash
-        run: |
-          curl -s "https://get.sdkman.io" | bash
-          source "$HOME/.sdkman/bin/sdkman-init.sh"
-          sdk install kscript
 
       - name: Install dart dependencies
         if: ${{ !env.FOCUS || env.FOCUS == 'dart' }}
@@ -208,12 +203,8 @@ jobs:
 
       - name: Run tox
         shell: bash
-        # sdkman init can be replaced with actions setup when the following is fixed
-        # https://github.com/sdkman/sdkman-action/issues/8
         run: |
-          if [ -f $HOME/.sdkman/bin/sdkman-init.sh ]; then
-            source "$HOME/.sdkman/bin/sdkman-init.sh"
-          fi
+          set -ex
           LINT=1
           if [ "$RUNNER_OS" == "Windows" ]; then
             export PATH="$PATH:/C/Program Files/LLVM/bin:/tmp/v"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+# Contributing
+
 So you found a bug, fixed it and would like us to include it in the next release. If so, please
 read-on.
 
@@ -27,13 +29,13 @@ Here are some notes for ubuntu 20.04
 
 ### Ubuntu 20.04 + python3
 
-```
+```bash
 sudo apt install python3 python3-pip python3-pytest tox black pyflakes3
 ```
 
 ### Ubuntu 20.04 + C++
 
-```
+```bash
 sudo apt install clang-format clang++ libc++-dev libc++abi-dev
 ```
 
@@ -41,41 +43,27 @@ sudo apt install clang-format clang++ libc++-dev libc++abi-dev
 
 - Follow https://rustup.rs/
 
-```
+```bash
 rustup component add rustfmt
-cargo install cargo-script
+cargo install cargo-eval
 ```
 
 ## MacOS dependencies
 
 The following commands will install most of the dependencies on MacOS
 
+```bash
+brew install astyle clang-format flutter gcc go julia kotlin nim rust vlang z3
+cargo install cargo-eval
 ```
-brew tap holgerbrandl/tap https://github.com/holgerbrandl/homebrew-tap
-brew tap sdkman/tap
-brew install astyle clang-format cljstyle flutter gcc go julia kscript ktlint nim sdkman-cli vlang z3
-cargo install cargo-script
-```
-
-`cljstyle` will refuse to run.  In a shell, type `open /usr/local/bin/`, locate `cljstyle`, and Open.
-MacOS will inform that it was downloaded from the Internet and ask for confirmation.
-Once confirmed, it will become usable.
 
 ## Running tests for C++ only
 
-```
-alias t=`pytest-3`
-t -k cpp -v
+```bash
+pytest-3 -k cpp -v
 ```
 
-Other languages will be similar
-
-
-## Running basic coverage test for all languages
-
-```
-pytest-3 -k coverage -v
-```
+Other languages will be similar.
 
 ## Updating expected output
 
@@ -83,18 +71,18 @@ Most test cases live in `<repo>/tests/cases/*.py` and the expected output after
 transpilation are in `<repo>/tests/expected`. If you make changes to any of the
 tests, follow the recipe below and inspect the updated files in `tests/expected`.
 
-```
+```bash
 export UPDATE_EXPECTED=1
-t -k changed_tests_filter -v
+pytest-3 -k cli -v
 ```
 
 When tests are run, temporary files are generated, compared against expected
 golden output and then discarded. If you want to keep them around for debugging
 purposes, you can use:
 
-```
+```bash
 export KEEP_EXISTING=1
-t -k some_test -v
+pytest-3 -k some_test -v
 ```
 
 ## Running tests via CI

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ passenv =
     LINT
     GOPATH
     GOCACHE
+    JAVA_HOME
+    KOTLIN_HOME
 deps =
     git+https://github.com/zuo/unittest_expander
     pytest-cov


### PR DESCRIPTION
Following on from https://github.com/py2many/py2many/pull/539 , jgo is now used for kscript also, which means Windows can now also easily run the Kotlin tests.

Kotlin still needs to be installed, and `KOTLIN_HOME` needs to be set.  https://github.com/scijava/jgo/issues/89 is the issue for running kotlin directly from jgo without it being installed first.