### PR TITLE
Feature/suport external modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ target/
 Cargo.lock
 go.mod
 go.sum
+.vscode/

--- a/py2many/cli.py
+++ b/py2many/cli.py
@@ -32,6 +32,21 @@ from .rewriters import (
 from .scope import add_scope_context
 from .toposort_modules import toposort
 
+
+from py2many.rewriters import (
+    ComplexDestructuringRewriter,
+    FStringJoinRewriter,
+    LoopElseRewriter,
+    PythonMainRewriter,
+    DocStringToCommentRewriter,
+    PrintBoolRewriter,
+    StrStrRewriter,
+    WithToBlockTransformer,
+    IgnoredAssignRewriter,
+    UnpackScopeRewriter,
+    UnitTestRewriter,
+)
+
 PY2MANY_DIR = Path(__file__).parent
 ROOT_DIR = PY2MANY_DIR.parent
 STDIN = "-"
@@ -90,6 +105,7 @@ def _transpile(
         PrintBoolRewriter(language),
         StrStrRewriter(language),
         UnpackScopeRewriter(language),
+        UnitTestRewriter(language),
     ]
     if settings.ext != ".py":
         generic_post_rewriters.append(LoopElseRewriter(language))

--- a/pyjl/__init__.py
+++ b/pyjl/__init__.py
@@ -7,7 +7,7 @@ from py2many.language import LanguageSettings
 from py2many.process_helpers import find_executable
 
 from .inference import infer_julia_types
-from .rewriters import JuliaBoolOpRewriter, JuliaIndexingRewriter
+from .rewriters import JuliaBoolOpRewriter, JuliaIndexingRewriter, JuliaUnittestRewriter
 from .transpiler import JuliaMethodCallRewriter, JuliaTranspiler
 
 
@@ -44,5 +44,6 @@ def settings(args, env=os.environ):
             JuliaIndexingRewriter(),
             JuliaMethodCallRewriter(),
             JuliaBoolOpRewriter(),
+            JuliaUnittestRewriter(),
         ],
     )

--- a/pyjl/julia_ast.py
+++ b/pyjl/julia_ast.py
@@ -1,0 +1,163 @@
+"""
+    julia AST
+
+    Helps with the conversion of Python's ast to Julia
+"""
+import ast
+from typing import Any, Optional
+
+
+######################################
+############### Types ################
+######################################
+class AbstractType(ast.Expr):
+    value: ast.expr
+    extends: ast.expr
+    ctx: ast.expr_context
+
+
+class LetStmt(ast.Lambda):
+    args: list[ast.expr]
+    body: list[ast.expr]
+    ctx: ast.expr_context
+
+
+class JuliaModule(ast.Module):
+    name: ast.Name
+    body: list[ast.expr]
+    ctx: ast.expr_context
+
+
+class OrderedDict(ast.Dict):
+    keys: list[ast.expr]
+    values: list[ast.expr]
+    annotation: ast.expr
+
+
+class OrderedDictComp(ast.DictComp):
+    key: ast.expr
+    value: ast.expr
+    generators: list[ast.comprehension]
+    annotation: ast.expr
+
+
+class OrderedSet(ast.Set):
+    elts: list[ast.expr]
+    annotation: ast.expr
+
+
+class Block(ast.FunctionDef):
+    name: str
+    block_expr: Optional[ast.expr]
+    args: ast.arguments
+    body: list[ast.expr]
+    returns: ast.expr
+    decorator_list: list[ast.expr]
+    block_type: str
+    ctx: ast.expr_context
+
+
+class Constructor(ast.FunctionDef):
+    name: str
+    args: ast.arguments
+    body: list[ast.expr]
+    returns: ast.expr
+    ctx: ast.expr_context
+
+
+class Symbol(ast.Name):
+    id: str
+
+
+# Julia lambdas allows multiline functions,
+# whereas Python's equivalent construct
+# does not does not
+class JuliaLambda(ast.FunctionDef):
+    name: str  # Should always be None
+    args: ast.arguments
+    body: list[ast.expr]
+    returns: ast.expr
+    ctx: ast.expr_context
+
+
+class InlineFunction(ast.FunctionDef):
+    name: str
+    args: ast.arguments
+    body: list[ast.expr]  # Restriction: Only first element is evaluated
+    returns: ast.expr  # By default, is empty
+    ctx: ast.expr_context
+
+
+######################################
+############### Parser ###############
+######################################
+
+
+class JuliaNodeVisitor(ast.NodeVisitor):
+    def visit_AbstractType(self, node: AbstractType) -> Any:
+        """Visit abstract type node."""
+        self.visit(node.value)
+        self.visit(node.extends)
+        return node
+
+    def visit_LetStmt(self, node: LetStmt) -> Any:
+        """Visit Julia let statement"""
+        self.visit_Lambda(node)
+        return node
+
+    def visit_JuliaModule(self, node: JuliaModule) -> Any:
+        """Visit Julia Module (a wrapper arround ast.Module)"""
+        self.visit_Module(node)
+        return node
+
+    def visit_OrderedDict(self, node: OrderedDict) -> Any:
+        """Visit Julia Ordered Dictionary (maintain the insertion order)"""
+        for k in node.keys:
+            self.visit(k)
+        for v in node.values:
+            self.visit(v)
+        return node
+
+    def visit_OrderedDictComp(self, node: OrderedDictComp) -> Any:
+        """Visit Julia Ordered Dictionary (maintain the insertion order)"""
+        self.visit(node.key)
+        self.visit(node.value)
+        for g in node.generators:
+            self.visit(g)
+        return node
+
+    def visit_OrderedSet(self, node: OrderedSet) -> Any:
+        """Visit Julia Ordered Sets (maintain the insertion order)"""
+        for e in node.elts:
+            self.visit(e)
+        return node
+
+    def visit_Block(self, node: Block) -> Any:
+        """Visit Julia Block"""
+        self.visit_FunctionDef(node)
+        return node
+
+    def visit_Constructor(self, node: Constructor) -> Any:
+        """Visit Julia Constructor"""
+        self.visit_FunctionDef(node)
+        return node
+
+    def visit_Symbol(self, node: Symbol) -> Any:
+        """Visit Julia Symbol"""
+        self.visit_Name(node)
+        return node
+
+    def visit_JuliaLambda(self, node: JuliaLambda) -> Any:
+        """Visit Julia lambda"""
+        self.visit_FunctionDef(node)
+        return node
+
+    def visit_InlineFunction(self, node: InlineFunction) -> Any:
+        """Visit Julia inline function"""
+        self.visit_FunctionDef(node)
+        return node
+
+
+class JuliaNodeTransformer(JuliaNodeVisitor):
+    def __init__(self) -> None:
+        super().__init__()

--- a/pyjl/transpiler.py
+++ b/pyjl/transpiler.py
@@ -1,6 +1,6 @@
 import ast
 import textwrap
-from typing import List, Tuple
+from typing import List, Tuple, Any
 
 from py2many.analysis import get_id, is_void_function
 from py2many.clike import _AUTO_INVOKED, class_for_typename
@@ -17,6 +17,15 @@ from .plugins import (
     SMALL_DISPATCH_MAP,
     SMALL_USINGS_MAP,
 )
+
+from py2many.analysis import get_id, is_void_function
+from py2many.declaration_extractor import DeclarationExtractor
+from py2many.clike import _AUTO_INVOKED, class_for_typename
+from py2many.tracer import is_list, defined_before, is_class_or_module, is_enum
+
+from pyjl import julia_ast
+
+from typing import List, Tuple
 
 
 class JuliaMethodCallRewriter(ast.NodeTransformer):
@@ -604,3 +613,18 @@ class JuliaTranspiler(CLikeTranspiler):
         orelse = self.visit(node.orelse)
         test = self.visit(node.test)
         return f"{test} ? ({body}) : ({orelse})"
+
+    ############################################
+    ############### Julia Nodes ################
+    ############################################
+    def visit_LetStmt(self, node: julia_ast.LetStmt) -> Any:
+        args = [self.visit(arg) for arg in node.args]
+        args_str = ", ".join(args)
+
+        # Visit let body
+        body = []
+        for n in node.body:
+            body.append(self.visit(n))
+        body = "\n".join(body)
+
+        return f"let {args_str}\n{body}\nend"

--- a/tests/cases/unittest.py
+++ b/tests/cases/unittest.py
@@ -1,0 +1,15 @@
+import unittest
+
+class UnitTestTranslation(unittest.TestCase):
+    def testSequences(self):
+        x = [1, 2]
+        z = x  # Added
+
+        self.assertEqual(z, [1, 2])
+
+        x = [1, 2, 3]
+        y = x
+        self.assertTrue(x is y)
+
+if __name__ =="__main__":
+    unittest.main()

--- a/tests/expected/unittest.jl
+++ b/tests/expected/unittest.jl
@@ -1,0 +1,20 @@
+import unittest
+struct UnitTestTranslation
+
+end
+
+function testSequences(self::UnitTestTranslation)
+    x = [1, 2]
+    z = x
+    assertEqual(self, z, [1, 2])
+    x = [1, 2, 3]
+    y = x
+    assertTrue(self)
+end
+
+function main()
+    unit_test_translation = UnitTestTranslation()
+    testSequences(unit_test_translation)
+end
+
+main()

--- a/tests/expected/unittest.py
+++ b/tests/expected/unittest.py
@@ -1,0 +1,15 @@
+import unittest
+
+class UnitTestTranslation(unittest.TestCase):
+    def testSequences(self):
+        x = [1, 2]
+        z = x  # Added
+
+        self.assertEqual(z, [1, 2])
+
+        x = [1, 2, 3]
+        y = x
+        self.assertTrue(x is y)
+
+if __name__ =="__main__":
+    unittest.main()


### PR DESCRIPTION
Supporting external modules. At the moment, it was only tested with pyjl, but it should allow modules, such s `unittest`, to be added separately from the main dictionaries.