### PR TITLE
Restore z3/smt behavior to be the same as z3py

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,6 +87,12 @@ jobs:
         run: |
           scripts/go-setup.sh
 
+      - name: Install SMT packages
+        if: ${{ !env.FOCUS || env.FOCUS == 'smt' }}
+        shell: bash
+        run: |
+          echo "$(pwd)/scripts/" >> $GITHUB_PATH
+
       - name: Install tox
         run: |
           pip3 --version

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,13 @@ ARG NIM
 ARG KOTLIN
 ARG DART
 ARG VLANG
+ARG SMT
+
+RUN useradd --create-home --comment "Arch Build User" build
+ENV HOME /home/build
+ENV PATH "$PATH:/home/build/.local/bin:/home/build/.cargo/bin:/home/build/bin"
+RUN usermod -aG wheel build
+RUN echo '%wheel ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 RUN pacman -Syu --noconfirm python python-pip unzip git
 
@@ -33,6 +40,12 @@ RUN test -z "$NIM" || pacman -Syu --noconfirm nim
 # Kotlin
 RUN test -z "$KOTLIN" || pacman -Syu --noconfirm kotlin
 
+# Install yay
+USER build
+RUN cd $HOME && git clone https://aur.archlinux.org/yay-bin.git && cd yay-bin && makepkg -s
+USER root
+RUN cd $HOME/yay-bin && pacman -U --noconfirm *.zst && cd .. && rm -rf yay-bin
+
 # Vlang:
 RUN test -z "$VLANG" || (RUNNER_OS=Linux RELEASE=weekly.2021.29 \
     FILE=v_$(echo ${RUNNER_OS} | tr '[:upper:]' '[:lower:]').zip \
@@ -42,10 +55,6 @@ RUN test -z "$VLANG" || (RUNNER_OS=Linux RELEASE=weekly.2021.29 \
 
 # TODO: add flutter
 # TODO: Add all formatters and other auxilliary setup from main.yml
-
-RUN useradd --create-home --comment "Arch Build User" build
-ENV HOME /home/build
-ENV PATH "$PATH:/home/build/.local/bin:/home/build/.cargo/bin:/home/build/bin"
 
 USER build
 RUN mkdir -p /home/build/bin
@@ -65,6 +74,9 @@ RUN test -z "$RUST" || (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.r
 
 # Go
 RUN test -z "$GOLANG" || /scripts/go-setup.sh
+
+# SMT
+RUN test -z "$SMT" || yay -S --noconfirm cljstyle-bin
 
 # Julia
 RUN test -z "$JULIA" || (julia -e 'using Pkg; Pkg.add("JuliaFormatter")' && \

--- a/pysmt/__init__.py
+++ b/pysmt/__init__.py
@@ -12,12 +12,7 @@ def settings(args, env=os.environ):
         ".smt",
         "SMT",
         [
-            "jgo",
-            "--repository",
-            "clojars.org=https://repo.clojars.org",
-            "mvxcvi:cljstyle:RELEASE:clojure.main",
-            "-m",
-            "cljstyle.main",
+            "cljstyle",
             "fix",
         ],
         None,

--- a/scripts/cljstyle
+++ b/scripts/cljstyle
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+jgo --repository clojars.org=https://repo.clojars.org mvxcvi:cljstyle:RELEASE:clojure.main -m cljstyle.main $*
+

--- a/tests/cases/demorgan.py
+++ b/tests/cases/demorgan.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
 
-from py2many.smt import check_sat, get_value
+from py2many.smt import check_sat
 
 
 def demorgan(a: bool, b: bool) -> bool:
     (a and b) == (not ((not a) or (not b)))
 
 
-assert demorgan
+assert not demorgan
 check_sat()
-get_value((a, b))

--- a/tests/expected/demorgan.smt
+++ b/tests/expected/demorgan.smt
@@ -7,6 +7,5 @@
   (= (and a b) (not (or (not a) (not b)))))
 
 
-(assert demorgan)
+(assert (not demorgan))
 (check-sat)
-(get-value (a b))


### PR DESCRIPTION
Related to #508 

z3 has a somewhat counter intuitive interface, which is reflected in z3py [examples](https://ericpony.github.io/z3py-tutorial/guide-examples.htm).

In order to prove `something`, they construct a test case for `!something` and verify that it's `unsat`.