### PR TITLE
Make _typename_from_annotation a classmethod

### DIFF
--- a/pyrs/clike.py
+++ b/pyrs/clike.py
@@ -5,6 +5,7 @@ from py2many.clike import LifeTime
 
 from .inference import (
     RUST_RANK_TO_TYPE,
+    RUST_CONTAINER_TYPE_MAP,
     RUST_TYPE_MAP,
     RUST_WIDTH_RANK,
     is_rust_reference,
@@ -37,11 +38,13 @@ RUST_KEYWORDS = frozenset(
 class CLikeTranspiler(CommonCLikeTranspiler):
     def __init__(self):
         super().__init__()
-        self._type_map = RUST_TYPE_MAP
+        CommonCLikeTranspiler._type_map = RUST_TYPE_MAP
+        CommonCLikeTranspiler._container_type_map = RUST_CONTAINER_TYPE_MAP
         self._keywords = RUST_KEYWORDS
 
-    def _map_type(self, typename, lifetime=LifeTime.UNKNOWN) -> str:
-        ret = super()._map_type(typename, lifetime)
+    @classmethod
+    def _map_type(cls, typename, lifetime=LifeTime.UNKNOWN) -> str:
+        ret = CommonCLikeTranspiler._map_type(typename, lifetime)
         if lifetime == LifeTime.STATIC:
             assert ret[0] == "&"
             return f"&'static {ret[1:]}"

--- a/pyrs/clike.py
+++ b/pyrs/clike.py
@@ -4,8 +4,8 @@ from py2many.clike import CLikeTranspiler as CommonCLikeTranspiler
 from py2many.clike import LifeTime
 
 from .inference import (
-    RUST_RANK_TO_TYPE,
     RUST_CONTAINER_TYPE_MAP,
+    RUST_RANK_TO_TYPE,
     RUST_TYPE_MAP,
     RUST_WIDTH_RANK,
     is_rust_reference,

--- a/pyrs/clike.py
+++ b/pyrs/clike.py
@@ -45,8 +45,7 @@ class CLikeTranspiler(CommonCLikeTranspiler):
     @classmethod
     def _map_type(cls, typename, lifetime=LifeTime.UNKNOWN) -> str:
         ret = CommonCLikeTranspiler._map_type(typename, lifetime)
-        if lifetime == LifeTime.STATIC:
-            assert ret[0] == "&"
+        if lifetime == LifeTime.STATIC and ret[0] == "&":
             return f"&'static {ret[1:]}"
         return ret
 

--- a/pyrs/inference.py
+++ b/pyrs/inference.py
@@ -34,6 +34,14 @@ RUST_TYPE_MAP = {
     c_uint64: "u64",
 }
 
+RUST_CONTAINER_TYPE_MAP = {
+    "List": "Vec",
+    "Dict": "HashMap",
+    "Set": "HashSet",
+    "Optional": "Option",
+    "Result": "Result",
+}
+
 # https://pyo3.rs/v0.13.2/conversions/tables.html
 RUST_EXTENSION_TYPE_MAP = {
     str: "&PyUnicode",

--- a/pyrs/transpiler.py
+++ b/pyrs/transpiler.py
@@ -77,18 +77,9 @@ class RustStringJoinRewriter(ast.NodeTransformer):
 class RustTranspiler(CLikeTranspiler):
     NAME = "rust"
 
-    CONTAINER_TYPE_MAP = {
-        "List": "Vec",
-        "Dict": "HashMap",
-        "Set": "HashSet",
-        "Optional": "Option",
-        "Result": "Result",
-    }
-
     def __init__(self, extension: bool = False, no_prologue: bool = False):
         super().__init__()
-        self._container_type_map = self.CONTAINER_TYPE_MAP
-        self._default_type = "_"
+        CLikeTranspiler._default_type = "_"
         self._extension = extension
         self._rust_ignored_module_set = {"argparse_dataclass"}
         self._no_prologue = no_prologue


### PR DESCRIPTION
There is a long standing code duplication issue:

py$lang/inference.py uses `get_id(node.annotation)` to infer types.
py$lang/transpiler.py uses ` _typename_from_annotation(node)` to infer types.

The latter is more powerful and should be used in `inference.py` as well. However, due to a circular dependency, inference.py can't use `_typename_from_annotation`. One way to resolve it by organizing type inference code into a sequence of classmethods.

This PR does it only for rust. If it passes tests, we could repeat it for all other targets and then fix up `inference.py` to use the more comprehensive method.
