### PR TITLE
Remove dependency on unitest and unittest_expander

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,13 +2,14 @@ import argparse
 import logging
 import os.path
 import platform
-import pytest
 import sys
 from functools import lru_cache
 from itertools import product
 from pathlib import Path
 from subprocess import run
 from unittest.mock import Mock
+
+import pytest
 
 from py2many.cli import (
     _create_cmd,

--- a/tests/test_unsupported.py
+++ b/tests/test_unsupported.py
@@ -1,12 +1,13 @@
 import ast
 import os.path
-import pytest
 import sys
 from functools import lru_cache, partial
 from itertools import product
 from subprocess import run
 from textwrap import dedent
 from unittest.mock import Mock
+
+import pytest
 
 try:
     from astpretty import pprint as ast_pretty_print

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,6 @@ passenv =
     KOTLIN_HOME
 deps =
     py38: importlib-resources
-    unittest-expander
     pytest-cov
     black
     astpretty


### PR DESCRIPTION
This unlocks the capability to run a specific test for a specific language:

```
pytest -k bubble_sort-rust
```