### PR TITLE
py2many: add lambda to scopes for type inference

### DIFF
--- a/py2many/scope.py
+++ b/py2many/scope.py
@@ -1,6 +1,6 @@
 import ast
-from contextlib import contextmanager
 from collections.abc import Iterable
+from contextlib import contextmanager
 
 from py2many.analysis import get_id
 

--- a/py2many/tracer.py
+++ b/py2many/tracer.py
@@ -1,6 +1,7 @@
 # Trace object types that are inserted into Python list.
 
 import ast
+from collections.abc import Iterable
 from typing import Optional
 
 from py2many.analysis import get_id
@@ -11,6 +12,8 @@ from py2many.exceptions import AstNotImplementedError
 # TODO: is it slow? is it correct?
 def _lookup_class_or_module(name, scopes) -> Optional[ast.ClassDef]:
     for scope in scopes:
+        if not isinstance(scope.body, Iterable):
+            continue
         for entry in scope.body:
             if isinstance(entry, ast.ClassDef):
                 if entry.name == name:


### PR DESCRIPTION
Previously we were not adding lambdas to the parent scopes.
Doing so is necessary for type inference of lambda arguments.

Related to: #622 