### PR TITLE
Fix Go class method receiver syntax (#731)

### DIFF
--- a/tests/expected/classes.go
+++ b/tests/expected/classes.go
@@ -7,17 +7,17 @@ import (
 type Foo struct {
 }
 
-func bar(self Foo) int {
-	return baz(self)
+func (self Foo) bar() int {
+	return self.baz()
 }
 
-func baz(self Foo) int {
+func (self Foo) baz() int {
 	return 10
 }
 
 func main() {
 	var f Foo = Foo{}
-	b := bar(f)
+	b := f.bar()
 	fmt.Printf("%v\n", b)
 	if !(b == 10) {
 		panic("assert")

--- a/tests/expected/cls.go
+++ b/tests/expected/cls.go
@@ -7,12 +7,12 @@ import (
 type Foo struct {
 }
 
-func bar(self Foo) string {
+func (self Foo) bar() string {
 	return "a"
 }
 
 func main() {
 	var f Foo = Foo{}
-	b := bar(f)
+	b := f.bar()
 	fmt.Printf("%v\n", b)
 }

--- a/tests/expected/rect.go
+++ b/tests/expected/rect.go
@@ -11,17 +11,17 @@ type Rectangle struct {
 	length int
 }
 
-func is_square(self Rectangle) bool {
+func (self Rectangle) is_square() bool {
 	return self.height == self.length
 }
 
 func Show() {
 	var r Rectangle = Rectangle{height: 1, length: 1}
-	if !(is_square(r)) {
+	if !(r.is_square()) {
 		panic("assert")
 	}
 	r = Rectangle{height: 1, length: 2}
-	if !(!(is_square(r))) {
+	if !(!(r.is_square())) {
 		panic("assert")
 	}
 	fmt.Printf("%v\n", r.height)


### PR DESCRIPTION
Fixes: #731

- Changed visit_FunctionDef to use proper Go receiver syntax: func (self TypeName) methodName(args) instead of func methodName(self TypeName, args)
- Modified GoMethodCallRewriter to not convert method calls to function calls
- Updated expected test outputs for classes.go, cls.go, rect.go