### PR TITLE
Fix Constant object attribute errors

### DIFF
--- a/py2many/clike.py
+++ b/py2many/clike.py
@@ -462,7 +462,7 @@ class CLikeTranspiler(ast.NodeVisitor):
         return f'"{node_str}"'
 
     def visit_Bytes(self, node) -> str:
-        bytes_str = node.s
+        bytes_str = node.value if isinstance(node, ast.Constant) else node.s
         byte_array = ", ".join([hex(c) for c in bytes_str])
         return f"{{{byte_array}}}"
 

--- a/py2many/tracer.py
+++ b/py2many/tracer.py
@@ -41,6 +41,8 @@ def is_enum(name, scopes):
 
 def is_self_arg(name, scopes):
     for scope in scopes:
+        if not isinstance(scope.body, Iterable):
+            continue
         for entry in scope.body:
             if isinstance(entry, ast.FunctionDef):
                 if len(entry.args.args):
@@ -129,10 +131,10 @@ class ValueExpressionVisitor(ast.NodeVisitor):
         self._stack = []
 
     def visit_Constant(self, node):
-        return str(node.n)
+        return str(node.value)
 
     def visit_Str(self, node):
-        return node.s
+        return node.value if isinstance(node, ast.Constant) else node.s
 
     def visit_Name(self, node):
         name = get_id(node)

--- a/pycpp/transpiler.py
+++ b/pycpp/transpiler.py
@@ -396,7 +396,8 @@ class CppTranspiler(CLikeTranspiler):
 
     def visit_Bytes(self, node) -> str:
         byte_literal = super().visit_Bytes(node)
-        n = len(node.s)
+        bytes_str = node.value if isinstance(node, ast.Constant) else node.s
+        n = len(bytes_str)
         return f"((std::array<unsigned char, {n}>){byte_literal})"
 
     def visit_Name(self, node) -> str:

--- a/pyd/transpiler.py
+++ b/pyd/transpiler.py
@@ -194,7 +194,9 @@ class DTranspiler(CLikeTranspiler):
 
     def visit_Bytes(self, node) -> str:
         bytes_str = node.value if isinstance(node, ast.Constant) else node.s
-        return f"{bytes_str}".replace("'", '"')  # replace single quote with double quote
+        return f"{bytes_str}".replace(
+            "'", '"'
+        )  # replace single quote with double quote
 
     def visit_Compare(self, node) -> str:
         left = self.visit(node.left)

--- a/pyd/transpiler.py
+++ b/pyd/transpiler.py
@@ -193,8 +193,8 @@ class DTranspiler(CLikeTranspiler):
         return "" + super().visit_Str(node) + ""
 
     def visit_Bytes(self, node) -> str:
-        bytes_str = f"{node.s}"
-        return bytes_str.replace("'", '"')  # replace single quote with double quote
+        bytes_str = node.value if isinstance(node, ast.Constant) else node.s
+        return f"{bytes_str}".replace("'", '"')  # replace single quote with double quote
 
     def visit_Compare(self, node) -> str:
         left = self.visit(node.left)

--- a/pydart/transpiler.py
+++ b/pydart/transpiler.py
@@ -176,7 +176,9 @@ class DartTranspiler(CLikeTranspiler):
 
     def visit_Bytes(self, node) -> str:
         bytes_str = node.value if isinstance(node, ast.Constant) else node.s
-        return f"{bytes_str}".replace("'", '"')  # replace single quote with double quote
+        return f"{bytes_str}".replace(
+            "'", '"'
+        )  # replace single quote with double quote
 
     def visit_Compare(self, node) -> str:
         left = self.visit(node.left)

--- a/pydart/transpiler.py
+++ b/pydart/transpiler.py
@@ -175,8 +175,8 @@ class DartTranspiler(CLikeTranspiler):
         return "" + super().visit_Str(node) + ""
 
     def visit_Bytes(self, node) -> str:
-        bytes_str = f"{node.s}"
-        return bytes_str.replace("'", '"')  # replace single quote with double quote
+        bytes_str = node.value if isinstance(node, ast.Constant) else node.s
+        return f"{bytes_str}".replace("'", '"')  # replace single quote with double quote
 
     def visit_Compare(self, node) -> str:
         left = self.visit(node.left)

--- a/pygo/transpiler.py
+++ b/pygo/transpiler.py
@@ -328,8 +328,8 @@ class GoTranspiler(CLikeTranspiler):
         return "" + super().visit_Str(node) + ""
 
     def visit_Bytes(self, node) -> str:
-        bytes_str = f"{node.s}"
-        return bytes_str.replace("'", '"')  # replace single quote with double quote
+        bytes_str = node.value if isinstance(node, ast.Constant) else node.s
+        return f"{bytes_str}".replace("'", '"')  # replace single quote with double quote
 
     def _visit_container_compare(self, node) -> str:
         left = self.visit(node.left)

--- a/pygo/transpiler.py
+++ b/pygo/transpiler.py
@@ -329,7 +329,9 @@ class GoTranspiler(CLikeTranspiler):
 
     def visit_Bytes(self, node) -> str:
         bytes_str = node.value if isinstance(node, ast.Constant) else node.s
-        return f"{bytes_str}".replace("'", '"')  # replace single quote with double quote
+        return f"{bytes_str}".replace(
+            "'", '"'
+        )  # replace single quote with double quote
 
     def _visit_container_compare(self, node) -> str:
         left = self.visit(node.left)

--- a/pyjl/transpiler.py
+++ b/pyjl/transpiler.py
@@ -219,7 +219,7 @@ class JuliaTranspiler(CLikeTranspiler):
         return "" + super().visit_Str(node) + ""
 
     def visit_Bytes(self, node) -> str:
-        bytes_str = node.s
+        bytes_str = node.value if isinstance(node, ast.Constant) else node.s
         bytes_str = bytes_str.replace(b'"', b'\\"')
         return 'b"' + bytes_str.decode("ascii", "backslashreplace") + '"'
 

--- a/pykt/transpiler.py
+++ b/pykt/transpiler.py
@@ -234,8 +234,8 @@ class KotlinTranspiler(CLikeTranspiler):
         return "" + super().visit_Str(node) + ""
 
     def visit_Bytes(self, node) -> str:
-        bytes_str = f"{node.s}"
-        return bytes_str.replace("'", '"')  # replace single quote with double quote
+        bytes_str = node.value if isinstance(node, ast.Constant) else node.s
+        return f"{bytes_str}".replace("'", '"')  # replace single quote with double quote
 
     def visit_Name(self, node) -> str:
         if node.id == "None":

--- a/pykt/transpiler.py
+++ b/pykt/transpiler.py
@@ -235,7 +235,9 @@ class KotlinTranspiler(CLikeTranspiler):
 
     def visit_Bytes(self, node) -> str:
         bytes_str = node.value if isinstance(node, ast.Constant) else node.s
-        return f"{bytes_str}".replace("'", '"')  # replace single quote with double quote
+        return f"{bytes_str}".replace(
+            "'", '"'
+        )  # replace single quote with double quote
 
     def visit_Name(self, node) -> str:
         if node.id == "None":

--- a/pymojo/transpiler.py
+++ b/pymojo/transpiler.py
@@ -206,8 +206,8 @@ class MojoTranspiler(CLikeTranspiler):
         return "" + super().visit_Str(node) + ""
 
     def visit_Bytes(self, node) -> str:
-        bytes_str = f"{node.s}"
-        return bytes_str.replace("'", '"')  # replace single quote with double quote
+        bytes_str = node.value if isinstance(node, ast.Constant) else node.s
+        return f"{bytes_str}".replace("'", '"')  # replace single quote with double quote
 
     def visit_Name(self, node) -> str:
         if node.id == "None":

--- a/pymojo/transpiler.py
+++ b/pymojo/transpiler.py
@@ -207,7 +207,9 @@ class MojoTranspiler(CLikeTranspiler):
 
     def visit_Bytes(self, node) -> str:
         bytes_str = node.value if isinstance(node, ast.Constant) else node.s
-        return f"{bytes_str}".replace("'", '"')  # replace single quote with double quote
+        return f"{bytes_str}".replace(
+            "'", '"'
+        )  # replace single quote with double quote
 
     def visit_Name(self, node) -> str:
         if node.id == "None":

--- a/pynim/transpiler.py
+++ b/pynim/transpiler.py
@@ -224,7 +224,9 @@ class NimTranspiler(CLikeTranspiler):
 
     def visit_Bytes(self, node) -> str:
         bytes_str = node.value if isinstance(node, ast.Constant) else node.s
-        return f"{bytes_str}".replace("'", '"')  # replace single quote with double quote
+        return f"{bytes_str}".replace(
+            "'", '"'
+        )  # replace single quote with double quote
 
     def visit_Name(self, node) -> str:
         if node.id == "None":

--- a/pynim/transpiler.py
+++ b/pynim/transpiler.py
@@ -223,8 +223,8 @@ class NimTranspiler(CLikeTranspiler):
         return "" + super().visit_Str(node) + ""
 
     def visit_Bytes(self, node) -> str:
-        bytes_str = f"{node.s}"
-        return bytes_str.replace("'", '"')  # replace single quote with double quote
+        bytes_str = node.value if isinstance(node, ast.Constant) else node.s
+        return f"{bytes_str}".replace("'", '"')  # replace single quote with double quote
 
     def visit_Name(self, node) -> str:
         if node.id == "None":

--- a/pyrs/transpiler.py
+++ b/pyrs/transpiler.py
@@ -412,9 +412,9 @@ class RustTranspiler(CLikeTranspiler):
         return "" + super().visit_Str(node) + ""
 
     def visit_Bytes(self, node) -> str:
-        bytes_str = node.s
-        bytes_str = bytes_str.replace(b'"', b'\\"')
-        return 'b"' + bytes_str.decode("ascii", "backslashreplace") + '"'
+        bytes_str = node.value if isinstance(node, ast.Constant) else node.s
+        byte_array = ", ".join([hex(c) for c in bytes_str])
+        return f"[{byte_array}].to_vec()"
 
     def visit_Compare(self, node) -> str:
         left = self.visit(node.left)

--- a/pyv/transpiler.py
+++ b/pyv/transpiler.py
@@ -629,12 +629,13 @@ class VTranspiler(CLikeTranspiler):
         return str(val)
 
     def visit_Bytes(self, node: ast.Constant) -> str:
-        if not node.s:
+        bytes_val = node.value if isinstance(node, ast.Constant) else node.s
+        if not bytes_val:
             return "[]byte{}"
 
         chars: List[str] = []
-        chars.append(f"byte({hex(node.s[0])})")
-        for c in node.s[1:]:
+        chars.append(f"byte({hex(bytes_val[0])})")
+        for c in bytes_val[1:]:
             chars.append(hex(c))
         return f"[{', '.join(chars)}]"
 

--- a/pyzig/transpiler.py
+++ b/pyzig/transpiler.py
@@ -221,8 +221,8 @@ class ZigTranspiler(CLikeTranspiler):
         return "" + super().visit_Str(node) + ""
 
     def visit_Bytes(self, node) -> str:
-        bytes_str = f"{node.s}"
-        return bytes_str.replace("'", '"')  # replace single quote with double quote
+        bytes_str = node.value if isinstance(node, ast.Constant) else node.s
+        return f"{bytes_str}".replace("'", '"')  # replace single quote with double quote
 
     def visit_Name(self, node) -> str:
         if node.id == "None":

--- a/pyzig/transpiler.py
+++ b/pyzig/transpiler.py
@@ -222,7 +222,9 @@ class ZigTranspiler(CLikeTranspiler):
 
     def visit_Bytes(self, node) -> str:
         bytes_str = node.value if isinstance(node, ast.Constant) else node.s
-        return f"{bytes_str}".replace("'", '"')  # replace single quote with double quote
+        return f"{bytes_str}".replace(
+            "'", '"'
+        )  # replace single quote with double quote
 
     def visit_Name(self, node) -> str:
         if node.id == "None":


### PR DESCRIPTION
Replace legacy AST attributes .s and .n with .value across the codebase to ensure compatibility with modern Python (3.8+).

 pycpp
 pygo
 pyd
 pydart
 pyjl
 pykt
 pymojo
 pynim
 pyrs
 pyv
 pyzig