### PR TITLE
vlang: add simple formatter

### DIFF
--- a/py2many/cli.py
+++ b/py2many/cli.py
@@ -256,7 +256,16 @@ def _format_one(settings, output_path, env=None):
             output_path = output_path.name
         cmd = _create_cmd(settings.formatter, filename=output_path)
         proc = run(cmd, env=env, capture_output=True)
-        if proc.returncode:
+
+        # Check for V specific formatting errors (sometimes return code is 0 but prints error)
+        v_error = False
+        if settings.ext == ".v":
+            # Check combined output just in case
+            output_combined = (proc.stderr + proc.stdout).lower()
+            if proc.returncode != 0 or b"error" in output_combined:
+                v_error = True
+
+        if proc.returncode or v_error:
             # format.jl exit code is unreliable
             if settings.ext == ".jl":
                 if proc.stderr is not None:
@@ -266,9 +275,36 @@ def _format_one(settings, output_path, env=None):
                     if b"ERROR: " in proc.stderr:
                         return False
                 return True
+
+            # Print the error from standard formatter so user sees it
             print(
                 f"Error: {cmd} (code: {proc.returncode}):\n{proc.stderr}{proc.stdout}"
             )
+
+            # V language fallback
+            if settings.ext == ".v":
+                print("Standard formatting failed, falling back to simple formatter...")
+                try:
+                    from . import vformat
+
+                    # Programmatic invocation
+                    with open(output_path, "r", encoding="utf-8") as f:
+                        content = f.read()
+
+                    formatted = vformat.format_v(content)
+
+                    with open(output_path, "w", encoding="utf-8") as f:
+                        f.write(formatted)
+
+                    if restore_cwd:
+                        os.chdir(restore_cwd)
+                    # Return False because standard formatting (validation) failed
+                    return False
+                except ImportError:
+                    print("Fallback failed: vformat module not found in package.")
+                except Exception as e:
+                    print(f"Fallback vformat callback failed: {e}")
+
             if restore_cwd:
                 os.chdir(restore_cwd)
             return False

--- a/py2many/vformat.py
+++ b/py2many/vformat.py
@@ -1,0 +1,141 @@
+import os
+import re
+import sys
+
+
+def hide_literals(line):
+    """
+    Replaces strings and comments with placeholders.
+    Returns (cleaned_line, placeholders_dict)
+    """
+    placeholders = {}
+
+    def repl(match):
+        key = f"__VV_PH_{len(placeholders)}__"
+        placeholders[key] = match.group(0)
+        return key
+
+    # Pattern for strings (double and single quotes) and comments
+    # We prioritize matching strings first so // inside string is kept
+    pattern = r'("[^"]*?"|\'[^\']*?\')|(//.*)'
+
+    # clean_line = re.sub(pattern, repl, line)
+    # re.sub with groups is tricky if we want to capture the whole match.
+    # The pattern (A)|(B) matches A or B. match.group(0) is the whole match.
+
+    clean_line = re.sub(pattern, repl, line)
+    return clean_line, placeholders
+
+
+def restore_literals(line, placeholders):
+    """Restores placeholders in the line."""
+    for key, value in placeholders.items():
+        line = line.replace(key, value)
+    return line
+
+
+def format_operators(line):
+    """Adds spaces around binary operators."""
+    # List of operators to pad.
+    # Order matters: longer (multi-char) operators first!
+    operators = [
+        "==",
+        "!=",
+        ">=",
+        "<=",
+        "&&",
+        "||",
+        "+=",
+        "-=",
+        "*=",
+        "/=",
+        "%=",
+        ":=",
+        "=",
+    ]
+    # We don't do + - * / % < > to avoid unary/generic issues in this simple script.
+
+    # We want to replace valid operators with " OP ".
+    # We must ensuring we don't double space if already spaced,
+    # AND we don't break things like `==` into ` = = ` (handled by sorting).
+
+    # Regex: \s*(OP)\s*  -> " \1 "
+    # We construct one big regex: \s*(==|!=|...)\s*
+
+    # Escape operators for regex
+    ops_escaped = [re.escape(op) for op in operators]
+    pattern_str = r"\s*(" + "|".join(ops_escaped) + r")\s*"
+
+    return re.sub(pattern_str, r" \1 ", line)
+
+
+def format_v(content):
+    lines = content.splitlines()
+    formatted_lines = []
+    level = 0
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            formatted_lines.append("")
+            continue
+
+        # 1. Hide strings/comments to protect them during formatting/analysis
+        clean_code, placeholders = hide_literals(stripped)
+
+        # 2. Format operators (on cleaned code)
+        clean_code = format_operators(clean_code)
+
+        # 3. Analyze braces for indentation (on cleaned code)
+        # Note: clean_code now has placeholders like __VV_PH_0__, no braces in them
+        n_open = clean_code.count("{")
+        n_close = clean_code.count("}")
+
+        # 4. Determine indentation
+        this_indent = level
+
+        # Simple dedent deduction handling
+        # If line starts with closing brace/paren, dedent this line
+        # We check the CLEAN code for start token
+        if clean_code.strip().startswith("}") or clean_code.strip().startswith(")"):
+            this_indent -= 1
+
+        if this_indent < 0:
+            this_indent = 0
+
+        # 5. Reconstruct line
+        # Restore literals into the formatted clean_code
+        final_line_content = restore_literals(clean_code, placeholders)
+
+        # trim again just in case operators added spaces at ends
+        final_line_content = final_line_content.strip()
+
+        formatted_lines.append("    " * this_indent + final_line_content)
+
+        # 6. Update level for next line
+        level += n_open - n_close
+
+        if level < 0:
+            level = 0
+
+    return "\n".join(formatted_lines) + "\n"
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python vformat.py <file.v>")
+        sys.exit(1)
+
+    path = sys.argv[1]
+    if not os.path.exists(path):
+        print(f"Error: File {path} not found")
+        sys.exit(1)
+
+    with open(path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    new_content = format_v(content)
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(new_content)
+    print(f"Formatted {path}")


### PR DESCRIPTION
When the standard formatter shows an error, the error is taken into account, but the simple formatter is triggered. This makes it easier to find errors in the generated file.