### PR TITLE
Improve Rust transpiler coverage

### DIFF
--- a/pyrs/__init__.py
+++ b/pyrs/__init__.py
@@ -9,6 +9,7 @@ from .transpiler import (
     RustNoneCompareRewriter,
     RustStringJoinRewriter,
     RustTranspiler,
+    RustWalrusRewriter,
 )
 
 
@@ -22,7 +23,7 @@ def settings(args, env=os.environ):
             "--edition=2021",
         ],
         None,
-        [RustNoneCompareRewriter()],
+        [RustNoneCompareRewriter(), RustWalrusRewriter()],
         [partial(infer_rust_types, extension=args.extension)],
         [RustLoopIndexRewriter(), RustStringJoinRewriter()],
         linter=[

--- a/pyrs/plugins.py
+++ b/pyrs/plugins.py
@@ -124,9 +124,32 @@ class RustTranspilerPlugins:
 
     def visit_print(self, node, vargs: List[str]) -> str:
         placeholders = []
-        for n in node.args:
-            placeholders.append("{}")
-        return 'println!("{}",{});'.format(" ".join(placeholders), ", ".join(vargs))
+        formatted_args = []
+        for arg, varg in zip(node.args, vargs):
+            definition = node.scopes.find(get_id(arg)) if get_id(arg) else None
+            assigned_from = getattr(definition, "assigned_from", None)
+            definition_value = getattr(assigned_from, "value", None)
+            is_split_result = (
+                isinstance(definition_value, ast.Call)
+                and isinstance(definition_value.func, ast.Attribute)
+                and definition_value.func.attr == "split"
+            )
+            if is_split_result:
+                placeholders.append("{}")
+                formatted_args.append(f'format!("{{:?}}", {varg}).replace("\\"", "\'")')
+            elif hasattr(arg, "container_type") or hasattr(
+                definition, "container_type"
+            ):
+                placeholders.append("{:?}")
+            else:
+                placeholders.append("{}")
+                formatted_args.append(varg)
+                continue
+            if not is_split_result:
+                formatted_args.append(varg)
+        return 'println!("{}",{});'.format(
+            " ".join(placeholders), ", ".join(formatted_args)
+        )
 
     def visit_exit(self, node, vargs) -> str:
         self._allows.add("unreachable_code")
@@ -162,6 +185,33 @@ class RustTranspilerPlugins:
     @staticmethod
     def visit_asyncio_run(node, vargs) -> str:
         return f"block_on({vargs[0]})"
+
+    def visit_re_search(self, node, vargs) -> str:
+        self._usings.add("regex::Regex")
+        return f"Regex::new({vargs[0]}).unwrap().is_match({vargs[1]})"
+
+    def visit_re_match(self, node, vargs) -> str:
+        self._usings.add("regex::Regex")
+        return (
+            f'Regex::new(&format!("^{{}}", {vargs[0]})).unwrap().is_match({vargs[1]})'
+        )
+
+    def visit_re_findall(self, node, vargs) -> str:
+        self._usings.add("regex::Regex")
+        return f"Regex::new({vargs[0]}).unwrap().find_iter({vargs[1]}).map(|m| m.as_str()).collect::<Vec<_>>()"
+
+    def visit_re_sub(self, node, vargs) -> str:
+        self._usings.add("regex::Regex")
+        return f"Regex::new({vargs[0]}).unwrap().replace_all({vargs[2]}, {vargs[1]})"
+
+    def visit_re_split(self, node, vargs) -> str:
+        self._usings.add("regex::Regex")
+        return f"Regex::new({vargs[0]}).unwrap().split({vargs[1]}).collect::<Vec<_>>()"
+
+    def visit_re_compile(self, node, vargs) -> str:
+        self._usings.add("regex::Regex")
+        self._allows.add("unused_variables")
+        return f"Regex::new({vargs[0]}).unwrap()"
 
 
 FIXED_SIZE_INT_MAP = {
@@ -199,6 +249,13 @@ DISPATCH_MAP = {
     "range": RustTranspilerPlugins.visit_range,
     "xrange": RustTranspilerPlugins.visit_range,
     "print": RustTranspilerPlugins.visit_print,
+    "re.search": RustTranspilerPlugins.visit_re_search,
+    "re.match": RustTranspilerPlugins.visit_re_match,
+    "re.match_": RustTranspilerPlugins.visit_re_match,
+    "re.findall": RustTranspilerPlugins.visit_re_findall,
+    "re.sub": RustTranspilerPlugins.visit_re_sub,
+    "re.split": RustTranspilerPlugins.visit_re_split,
+    "re.compile": RustTranspilerPlugins.visit_re_compile,
 }
 
 MODULE_DISPATCH_TABLE = {

--- a/pyrs/plugins.py
+++ b/pyrs/plugins.py
@@ -136,7 +136,7 @@ class RustTranspilerPlugins:
             )
             if is_split_result:
                 placeholders.append("{}")
-                formatted_args.append(f'format!("{{:?}}", {varg}).replace("\\"", "\'")')
+                formatted_args.append(f'format!("{{:?}}", {varg}).replace(\'"\', "\'")')
             elif hasattr(arg, "container_type") or hasattr(
                 definition, "container_type"
             ):

--- a/pyrs/transpiler.py
+++ b/pyrs/transpiler.py
@@ -74,6 +74,90 @@ class RustStringJoinRewriter(ast.NodeTransformer):
         return node
 
 
+class RustWalrusRewriter(ast.NodeTransformer):
+    def _has_walrus(self, node):
+        return any(isinstance(n, ast.NamedExpr) for n in ast.walk(node))
+
+    def visit_Module(self, node):
+        node.body = self._expand_body(node.body)
+        self.generic_visit(node)
+        return node
+
+    def visit_FunctionDef(self, node):
+        node.body = self._expand_body(node.body)
+        self.generic_visit(node)
+        return node
+
+    def visit_If(self, node):
+        node.body = self._expand_body(node.body)
+        node.orelse = self._expand_body(node.orelse)
+        self.generic_visit(node)
+        return node
+
+    def visit_While(self, node):
+        node.body = self._expand_body(node.body)
+        self.generic_visit(node)
+        return node
+
+    def visit_For(self, node):
+        node.body = self._expand_body(node.body)
+        self.generic_visit(node)
+        return node
+
+    def _expand_body(self, body):
+        if not body:
+            return body
+        new_body = []
+        for stmt in body:
+            if not self._has_walrus(stmt):
+                new_body.append(stmt)
+                continue
+
+            assignments = []
+
+            class WalrusExtractor(ast.NodeTransformer):
+                def visit_NamedExpr(self, named_expr):
+                    named_expr.value = self.visit(named_expr.value)
+                    assignments.append(
+                        ast.Assign(
+                            targets=[named_expr.target],
+                            value=named_expr.value,
+                            lineno=named_expr.lineno,
+                            col_offset=getattr(named_expr, "col_offset", 0),
+                        )
+                    )
+                    return named_expr.target
+
+            extractor = WalrusExtractor()
+
+            if isinstance(stmt, ast.While) and self._has_walrus(stmt.test):
+                new_test = extractor.visit(stmt.test)
+                break_if = ast.If(
+                    test=ast.UnaryOp(op=ast.Not(), operand=new_test),
+                    body=[ast.Break()],
+                    orelse=[],
+                    lineno=stmt.lineno,
+                    col_offset=getattr(stmt, "col_offset", 0),
+                )
+                stmt.test = ast.Constant(value=True, lineno=stmt.lineno)
+                stmt.body = assignments + [break_if] + stmt.body
+                ast.fix_missing_locations(stmt)
+                new_body.append(stmt)
+            else:
+                if isinstance(stmt, ast.If):
+                    stmt.test = extractor.visit(stmt.test)
+                elif isinstance(stmt, ast.For):
+                    stmt.iter = extractor.visit(stmt.iter)
+                elif hasattr(stmt, "value"):
+                    stmt.value = extractor.visit(stmt.value)
+                elif hasattr(stmt, "test"):
+                    stmt.test = extractor.visit(stmt.test)
+                ast.fix_missing_locations(stmt)
+                new_body.extend(assignments)
+                new_body.append(stmt)
+        return new_body
+
+
 class RustTranspiler(CLikeTranspiler):
     NAME = "rust"
 
@@ -81,7 +165,7 @@ class RustTranspiler(CLikeTranspiler):
         super().__init__()
         CLikeTranspiler._default_type = "_"
         self._extension = extension
-        self._rust_ignored_module_set = {"argparse_dataclass"}
+        self._rust_ignored_module_set = {"argparse_dataclass", "re"}
         self._no_prologue = no_prologue
         self._dispatch_map = DISPATCH_MAP
         self._small_dispatch_map = SMALL_DISPATCH_MAP
@@ -145,7 +229,9 @@ class RustTranspiler(CLikeTranspiler):
             if not self._no_prologue
             else ""
         )
-        lint_ignores += "\n".join(f"#![allow({allow})]" for allow in self._allows)
+        lint_ignores += "\n".join(
+            f"#![allow({allow})]" for allow in sorted(self._allows)
+        )
         cargo_toml = f"""\
         //! ```cargo
         //! [package]
@@ -375,6 +461,37 @@ class RustTranspiler(CLikeTranspiler):
         if node.keywords:
             vargs += [self.visit(kw.value) for kw in node.keywords]
 
+        if isinstance(node.func, ast.Attribute):
+            value = self.visit(node.func.value)
+            attr = node.func.attr
+            if attr == "lower":
+                return f"{value}.to_lowercase()"
+            if attr == "upper":
+                return f"{value}.to_uppercase()"
+            if attr == "capitalize":
+                return (
+                    f"{{ let mut c = {value}.chars(); match c.next() {{ "
+                    "None => String::new(), "
+                    "Some(f) => f.to_uppercase().collect::<String>() "
+                    "+ &c.as_str().to_lowercase() } }"
+                )
+            if attr == "strip":
+                return f"{value}.trim()"
+            if attr == "lstrip":
+                return f"{value}.trim_start()"
+            if attr == "rstrip":
+                return f"{value}.trim_end()"
+            if attr == "split" and not vargs:
+                return f"{value}.split_whitespace().collect::<Vec<_>>()"
+            if attr == "find" and len(vargs) == 1:
+                return f"{value}.find({vargs[0]}).map_or(-1, |i| i as i32)"
+            if attr == "isdigit":
+                return f"{value}.chars().all(|c| c.is_ascii_digit())"
+            if attr == "isalpha":
+                return f"{value}.chars().all(|c| c.is_alphabetic())"
+            if attr == "isspace":
+                return f"{value}.chars().all(|c| c.is_whitespace())"
+
         ret = self._dispatch(node, fname, vargs)
         node_result_type = getattr(node, "result_type", False)
         node_func_result_type = getattr(node.func, "result_type", False)
@@ -409,7 +526,13 @@ class RustTranspiler(CLikeTranspiler):
         return "\n".join(buf)
 
     def visit_Str(self, node) -> str:
-        return "" + super().visit_Str(node) + ""
+        node_str = node.value
+        node_str = node_str.replace("\\", "\\\\")
+        node_str = node_str.replace('"', '\\"')
+        node_str = node_str.replace("\n", "\\n")
+        node_str = node_str.replace("\r", "\\r")
+        node_str = node_str.replace("\t", "\\t")
+        return f'"{node_str}"'
 
     def visit_Bytes(self, node) -> str:
         bytes_str = self._get_bytes(node)
@@ -479,6 +602,37 @@ class RustTranspiler(CLikeTranspiler):
         else:
             return super().visit_NameConstant(node)
 
+    def _truthy_expr(self, node) -> str:
+        expr = self.visit(node)
+        if isinstance(node, ast.Constant):
+            if isinstance(node.value, bool):
+                return expr
+            if isinstance(node.value, (int, float)):
+                self._allows.add("unused_assignments")
+                self._allows.add("unused_variables")
+                return f"{expr} != 0"
+            if isinstance(node.value, str):
+                return f"!{expr}.is_empty()"
+        typename = self._typename_from_annotation(node)
+        if typename in {
+            "i8",
+            "u8",
+            "i16",
+            "u16",
+            "i32",
+            "u32",
+            "i64",
+            "u64",
+            "f32",
+            "f64",
+        }:
+            self._allows.add("unused_assignments")
+            self._allows.add("unused_variables")
+            return f"{expr} != 0"
+        if typename in {"&str", "String"}:
+            return f"!{expr}.is_empty()"
+        return expr
+
     def visit_If(self, node) -> str:
         body_vars = {get_id(v) for v in node.scopes[-1].body_vars}
         orelse_vars = {get_id(v) for v in node.scopes[-1].orelse_vars}
@@ -490,7 +644,16 @@ class RustTranspiler(CLikeTranspiler):
         #     definition = node.scopes.find(cv)
         #     var_type = decltype(definition)
         #     var_definitions.append("{0} {1};\n".format(var_type, cv))
-        ret = "".join(var_definitions) + super().visit_If(node, use_parens=False)
+        buf = [f"if {self._truthy_expr(node.test)} {{"]
+        body = [self.visit(child) for child in node.body]
+        body = [b for b in body if b is not None]
+        buf.extend(body)
+        orelse = [self.visit(child) for child in node.orelse]
+        if orelse:
+            buf.append("} else {")
+            buf.extend(orelse)
+        buf.append("}")
+        ret = "".join(var_definitions) + "\n".join(buf)
         # Sometimes if True: ... gets compiled into an expression, needing a semicolon
         make_block = (
             isinstance(node.test, ast.Constant)
@@ -502,7 +665,7 @@ class RustTranspiler(CLikeTranspiler):
         return ret
 
     def visit_While(self, node) -> str:
-        test = self.visit(node.test)
+        test = self._truthy_expr(node.test)
         if test == "true":
             body = [self.visit(n) for n in node.body]
             return "loop {{\n{}\n}}\n".format("\n".join(body))
@@ -519,6 +682,15 @@ class RustTranspiler(CLikeTranspiler):
             return super().visit_UnaryOp(node)
 
     def visit_BinOp(self, node) -> str:
+        if isinstance(node.op, ast.Pow):
+            left = self.visit(node.left)
+            right = self.visit(node.right)
+            left_type = self._typename_from_annotation(node.left)
+            if left_type in {"f32", "f64"}:
+                return f"{left}.powf({right})"
+            if left_type in {"i8", "u8", "i16", "u16", "i32", "u32", "i64", "u64"}:
+                return f"({left} as {left_type}).pow({right} as u32)"
+            return f"{left}.pow({right} as u32)"
         if (
             isinstance(node.left, ast.List)
             and isinstance(node.op, ast.Mult)
@@ -951,6 +1123,44 @@ class RustTranspiler(CLikeTranspiler):
 
     def visit_ListComp(self, node) -> str:
         return self.visit_GeneratorExp(node)  # right now they are the same
+
+    def visit_DictComp(self, node) -> str:
+        if not node.generators:
+            return "HashMap::new()"
+
+        self._usings.add("std::collections::HashMap")
+        buf = ["{", "let mut result = HashMap::new();"]
+
+        for generator in node.generators:
+            target = self.visit(generator.target)
+            iter_expr = self.visit(generator.iter)
+            is_range = (
+                ("range" in get_id(generator.iter.func))
+                if isinstance(generator.iter, ast.Call) and get_id(generator.iter.func)
+                else False
+            )
+            if not (
+                iter_expr.endswith("keys()")
+                or iter_expr.endswith("values()")
+                or is_range
+            ):
+                iter_expr += ".iter()"
+
+            buf.append(f"for {target} in {iter_expr} {{")
+            for if_clause in generator.ifs:
+                buf.append(f"if {self.visit(if_clause)} {{")
+
+            key = self.visit(node.key)
+            value = self.visit(node.value)
+            buf.append(f"result.insert({key}, {value});")
+
+            for _ in generator.ifs:
+                buf.append("}")
+            buf.append("}")
+
+        buf.append("result")
+        buf.append("}")
+        return "\n".join(buf)
 
     def visit_Global(self, node) -> str:
         return "//global {}".format(", ".join(node.names))

--- a/pyrs/transpiler.py
+++ b/pyrs/transpiler.py
@@ -644,6 +644,9 @@ class RustTranspiler(CLikeTranspiler):
         #     definition = node.scopes.find(cv)
         #     var_type = decltype(definition)
         #     var_definitions.append("{0} {1};\n".format(var_type, cv))
+        if self.is_block(node):
+            return f"{self._make_block(node)};"
+
         buf = [f"if {self._truthy_expr(node.test)} {{"]
         body = [self.visit(child) for child in node.body]
         body = [b for b in body if b is not None]
@@ -1127,6 +1130,15 @@ class RustTranspiler(CLikeTranspiler):
     def visit_DictComp(self, node) -> str:
         if not node.generators:
             return "HashMap::new()"
+
+        if any(
+            not (
+                isinstance(generator.iter, ast.Call)
+                and get_id(generator.iter.func) == "range"
+            )
+            for generator in node.generators
+        ):
+            return super().visit_DictComp(node)
 
         self._usings.add("std::collections::HashMap")
         buf = ["{", "let mut result = HashMap::new();"]

--- a/tests/expected/comparison.rs
+++ b/tests/expected/comparison.rs
@@ -1,0 +1,64 @@
+//! ```cargo
+//! [package]
+//! edition = "2021"
+//! [dependencies]
+//! anyhow = "*"
+//! ```
+
+#![allow(clippy::assertions_on_constants)]
+#![allow(clippy::bool_comparison)]
+#![allow(clippy::collapsible_else_if)]
+#![allow(clippy::comparison_to_empty)]
+#![allow(clippy::double_parens)] // https://github.com/adsharma/py2many/issues/17
+#![allow(clippy::eq_op)]
+#![allow(clippy::let_with_type_underscore)]
+#![allow(clippy::map_identity)]
+#![allow(clippy::needless_return)]
+#![allow(clippy::nonminimal_bool)]
+#![allow(clippy::partialeq_to_none)]
+#![allow(clippy::print_literal)]
+#![allow(clippy::ptr_arg)]
+#![allow(clippy::redundant_static_lifetimes)] // https://github.com/adsharma/py2many/issues/266
+#![allow(clippy::unnecessary_cast)]
+#![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::useless_vec)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(unused_imports)]
+#![allow(unused_mut)]
+#![allow(unused_parens)]
+#![allow(unused_assignments)]
+#![allow(unused_variables)]
+
+extern crate anyhow;
+use anyhow::Result;
+
+pub fn compare_with_integer_variable() {
+    let i: i32 = 0;
+    let mut s: i32 = 1;
+    if i != 0 {
+        s = 2;
+    } else {
+        s = 3;
+    }
+    assert!(s == 3);
+}
+
+pub fn use_zero_for_comparison() {
+    let i: i32 = 0;
+    let mut s: i32 = 1;
+    if 0 != 0 {
+        s = 2;
+    } else {
+        s = 3;
+    }
+    assert!(s == 3);
+}
+
+pub fn main() -> Result<()> {
+    compare_with_integer_variable();
+    use_zero_for_comparison();
+    println!("{}", "OK");
+    Ok(())
+}

--- a/tests/expected/dict_comp.rs
+++ b/tests/expected/dict_comp.rs
@@ -1,0 +1,60 @@
+//! ```cargo
+//! [package]
+//! edition = "2021"
+//! [dependencies]
+//! anyhow = "*"
+//! ```
+
+#![allow(clippy::assertions_on_constants)]
+#![allow(clippy::bool_comparison)]
+#![allow(clippy::collapsible_else_if)]
+#![allow(clippy::comparison_to_empty)]
+#![allow(clippy::double_parens)] // https://github.com/adsharma/py2many/issues/17
+#![allow(clippy::eq_op)]
+#![allow(clippy::let_with_type_underscore)]
+#![allow(clippy::map_identity)]
+#![allow(clippy::needless_return)]
+#![allow(clippy::nonminimal_bool)]
+#![allow(clippy::partialeq_to_none)]
+#![allow(clippy::print_literal)]
+#![allow(clippy::ptr_arg)]
+#![allow(clippy::redundant_static_lifetimes)] // https://github.com/adsharma/py2many/issues/266
+#![allow(clippy::unnecessary_cast)]
+#![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::useless_vec)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(unused_imports)]
+#![allow(unused_mut)]
+#![allow(unused_parens)]
+
+extern crate anyhow;
+use anyhow::Result;
+use std::collections::HashMap;
+
+pub fn show() {
+    let squares = {
+        let mut result = HashMap::new();
+        for x in (0..5) {
+            result.insert(x, (x * x));
+        }
+        result
+    };
+    println!("{}", squares.len() as i32);
+    let evens = {
+        let mut result = HashMap::new();
+        for x in (0..10) {
+            if ((x as i32) % 2) == 0 {
+                result.insert(x, ((x as i32) * 2));
+            }
+        }
+        result
+    };
+    println!("{}", evens.len() as i32);
+}
+
+pub fn main() -> Result<()> {
+    show();
+    Ok(())
+}

--- a/tests/expected/math_func.rs
+++ b/tests/expected/math_func.rs
@@ -1,0 +1,43 @@
+//! ```cargo
+//! [package]
+//! edition = "2021"
+//! [dependencies]
+//! anyhow = "*"
+//! ```
+
+#![allow(clippy::assertions_on_constants)]
+#![allow(clippy::bool_comparison)]
+#![allow(clippy::collapsible_else_if)]
+#![allow(clippy::comparison_to_empty)]
+#![allow(clippy::double_parens)] // https://github.com/adsharma/py2many/issues/17
+#![allow(clippy::eq_op)]
+#![allow(clippy::let_with_type_underscore)]
+#![allow(clippy::map_identity)]
+#![allow(clippy::needless_return)]
+#![allow(clippy::nonminimal_bool)]
+#![allow(clippy::partialeq_to_none)]
+#![allow(clippy::print_literal)]
+#![allow(clippy::ptr_arg)]
+#![allow(clippy::redundant_static_lifetimes)] // https://github.com/adsharma/py2many/issues/266
+#![allow(clippy::unnecessary_cast)]
+#![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::useless_vec)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(unused_imports)]
+#![allow(unused_mut)]
+#![allow(unused_parens)]
+
+extern crate anyhow;
+use anyhow::Result;
+
+pub fn main_func() {
+    let a: i32 = (2 as i32).pow(4 as u32);
+    println!("{}", a);
+}
+
+pub fn main() -> Result<()> {
+    main_func();
+    Ok(())
+}

--- a/tests/expected/regex_methods.rs
+++ b/tests/expected/regex_methods.rs
@@ -1,0 +1,66 @@
+//! ```cargo
+//! [package]
+//! edition = "2021"
+//! [dependencies]
+//! anyhow = "*"
+//! regex = "*"
+//! ```
+
+#![allow(clippy::assertions_on_constants)]
+#![allow(clippy::bool_comparison)]
+#![allow(clippy::collapsible_else_if)]
+#![allow(clippy::comparison_to_empty)]
+#![allow(clippy::double_parens)] // https://github.com/adsharma/py2many/issues/17
+#![allow(clippy::eq_op)]
+#![allow(clippy::let_with_type_underscore)]
+#![allow(clippy::map_identity)]
+#![allow(clippy::needless_return)]
+#![allow(clippy::nonminimal_bool)]
+#![allow(clippy::partialeq_to_none)]
+#![allow(clippy::print_literal)]
+#![allow(clippy::ptr_arg)]
+#![allow(clippy::redundant_static_lifetimes)] // https://github.com/adsharma/py2many/issues/266
+#![allow(clippy::unnecessary_cast)]
+#![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::useless_vec)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(unused_imports)]
+#![allow(unused_mut)]
+#![allow(unused_parens)]
+#![allow(unused_variables)]
+
+extern crate anyhow;
+extern crate regex;
+use anyhow::Result;
+use regex::Regex;
+
+pub fn test_re_methods() {
+    let text: &'static str = "The quick brown fox jumps over the lazy dog";
+    let search_res = Regex::new("fox").unwrap().is_match(text);
+    if search_res {
+        println!("{}", "Found fox");
+    }
+    let match_res = Regex::new(&format!("^{}", "The")).unwrap().is_match(text);
+    if match_res {
+        println!("{}", "Matched The");
+    }
+    let findall_res = Regex::new("\\w+")
+        .unwrap()
+        .find_iter(text)
+        .map(|m| m.as_str())
+        .collect::<Vec<_>>();
+    println!("{}", findall_res.len() as i32);
+    let sub_res = Regex::new("fox").unwrap().replace_all(text, "cat");
+    println!("{}", sub_res);
+    let split_res = Regex::new("\\s+").unwrap().split(text).collect::<Vec<_>>();
+    println!("{}", split_res.len() as i32);
+    let pattern = Regex::new("\\d+").unwrap();
+    println!("{}", "Pattern compiled");
+}
+
+pub fn main() -> Result<()> {
+    test_re_methods();
+    Ok(())
+}

--- a/tests/expected/test_stdlib_str.rs
+++ b/tests/expected/test_stdlib_str.rs
@@ -48,7 +48,7 @@ pub fn test_str_methods() {
     println!("{}", s.trim_start());
     println!("{}", s.trim_end());
     let parts = s.split_whitespace().collect::<Vec<_>>();
-    println!("{}", format!("{:?}", parts).replace("\"", "'"));
+    println!("{}", format!("{:?}", parts).replace('"', "'"));
     let joined = vec!["a", "b", "c"].join("-");
     println!("{}", joined);
     println!("{}", s.find("World").map_or(-1, |i| i as i32));

--- a/tests/expected/test_stdlib_str.rs
+++ b/tests/expected/test_stdlib_str.rs
@@ -1,0 +1,70 @@
+//! ```cargo
+//! [package]
+//! edition = "2021"
+//! [dependencies]
+//! anyhow = "*"
+//! ```
+
+#![allow(clippy::assertions_on_constants)]
+#![allow(clippy::bool_comparison)]
+#![allow(clippy::collapsible_else_if)]
+#![allow(clippy::comparison_to_empty)]
+#![allow(clippy::double_parens)] // https://github.com/adsharma/py2many/issues/17
+#![allow(clippy::eq_op)]
+#![allow(clippy::let_with_type_underscore)]
+#![allow(clippy::map_identity)]
+#![allow(clippy::needless_return)]
+#![allow(clippy::nonminimal_bool)]
+#![allow(clippy::partialeq_to_none)]
+#![allow(clippy::print_literal)]
+#![allow(clippy::ptr_arg)]
+#![allow(clippy::redundant_static_lifetimes)] // https://github.com/adsharma/py2many/issues/266
+#![allow(clippy::unnecessary_cast)]
+#![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::useless_vec)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(unused_imports)]
+#![allow(unused_mut)]
+#![allow(unused_parens)]
+
+extern crate anyhow;
+use anyhow::Result;
+use std::collections;
+
+pub fn test_str_methods() {
+    let s: &'static str = "  Hello World  ";
+    println!("{}", s.to_lowercase());
+    println!("{}", s.to_uppercase());
+    println!("{}", {
+        let mut c = s.chars();
+        match c.next() {
+            None => String::new(),
+            Some(f) => f.to_uppercase().collect::<String>() + &c.as_str().to_lowercase(),
+        }
+    });
+    println!("{}", s.trim());
+    println!("{}", s.trim_start());
+    println!("{}", s.trim_end());
+    let parts = s.split_whitespace().collect::<Vec<_>>();
+    println!("{}", format!("{:?}", parts).replace("\"", "'"));
+    let joined = vec!["a", "b", "c"].join("-");
+    println!("{}", joined);
+    println!("{}", s.find("World").map_or(-1, |i| i as i32));
+    println!("{}", s.replace("World", "Vlang"));
+    if "123".chars().all(|c| c.is_ascii_digit()) {
+        println!("{}", "digit");
+    }
+    if "abc".chars().all(|c| c.is_alphabetic()) {
+        println!("{}", "alpha");
+    }
+    if "   ".chars().all(|c| c.is_whitespace()) {
+        println!("{}", "space");
+    }
+}
+
+pub fn main() -> Result<()> {
+    test_str_methods();
+    Ok(())
+}

--- a/tests/expected/test_walrus_simple.rs
+++ b/tests/expected/test_walrus_simple.rs
@@ -1,0 +1,45 @@
+//! ```cargo
+//! [package]
+//! edition = "2021"
+//! [dependencies]
+//! anyhow = "*"
+//! ```
+
+#![allow(clippy::assertions_on_constants)]
+#![allow(clippy::bool_comparison)]
+#![allow(clippy::collapsible_else_if)]
+#![allow(clippy::comparison_to_empty)]
+#![allow(clippy::double_parens)] // https://github.com/adsharma/py2many/issues/17
+#![allow(clippy::eq_op)]
+#![allow(clippy::let_with_type_underscore)]
+#![allow(clippy::map_identity)]
+#![allow(clippy::needless_return)]
+#![allow(clippy::nonminimal_bool)]
+#![allow(clippy::partialeq_to_none)]
+#![allow(clippy::print_literal)]
+#![allow(clippy::ptr_arg)]
+#![allow(clippy::redundant_static_lifetimes)] // https://github.com/adsharma/py2many/issues/266
+#![allow(clippy::unnecessary_cast)]
+#![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::useless_vec)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(unused_imports)]
+#![allow(unused_mut)]
+#![allow(unused_parens)]
+
+extern crate anyhow;
+use anyhow::Result;
+
+pub fn show() {
+    let x: i32 = 5;
+    if x > 3 {
+        println!("{}", x);
+    }
+}
+
+pub fn main() -> Result<()> {
+    show();
+    Ok(())
+}

--- a/tests/expected/walrus.rs
+++ b/tests/expected/walrus.rs
@@ -1,0 +1,55 @@
+//! ```cargo
+//! [package]
+//! edition = "2021"
+//! [dependencies]
+//! anyhow = "*"
+//! ```
+
+#![allow(clippy::assertions_on_constants)]
+#![allow(clippy::bool_comparison)]
+#![allow(clippy::collapsible_else_if)]
+#![allow(clippy::comparison_to_empty)]
+#![allow(clippy::double_parens)] // https://github.com/adsharma/py2many/issues/17
+#![allow(clippy::eq_op)]
+#![allow(clippy::let_with_type_underscore)]
+#![allow(clippy::map_identity)]
+#![allow(clippy::needless_return)]
+#![allow(clippy::nonminimal_bool)]
+#![allow(clippy::partialeq_to_none)]
+#![allow(clippy::print_literal)]
+#![allow(clippy::ptr_arg)]
+#![allow(clippy::redundant_static_lifetimes)] // https://github.com/adsharma/py2many/issues/266
+#![allow(clippy::unnecessary_cast)]
+#![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::useless_vec)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(unused_imports)]
+#![allow(unused_mut)]
+#![allow(unused_parens)]
+
+extern crate anyhow;
+use anyhow::Result;
+use std::collections;
+
+pub fn show() {
+    let n = vec![1, 2, 3].len() as i32;
+    if (n as i32) > 2 {
+        println!("{}", n);
+    }
+    let mut i: i32 = 0;
+    loop {
+        let x: i32 = (i * 2);
+        if !(x < 10) {
+            break;
+        }
+        println!("{}", x);
+        i += 1;
+    }
+}
+
+pub fn main() -> Result<()> {
+    show();
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add Rust support for walrus lifting, dict comprehensions, regex calls, string methods, numeric truthiness, and integer exponentiation
- add Rust expected outputs for seven cases that now compile and match Python behavior
- keep unrelated untracked run.sh out of the commit

## Validation
- ruff check pyrs/__init__.py pyrs/plugins.py pyrs/transpiler.py
- LINT=0 pytest selected Rust cases for comparison, dict_comp, math_func, test_stdlib_str, test_walrus_simple, walrus
- LINT=0 pytest regex_methods-rust with Cargo network access