### PR TITLE
Update pymojo to emit mojo v0.26.2.0

### DIFF
--- a/pymojo/__init__.py
+++ b/pymojo/__init__.py
@@ -3,7 +3,11 @@ import os
 from py2many.language import LanguageSettings
 
 from .inference import infer_mojo_types
-from .rewriters import MojoImplicitConstructor, MojoInferMoveSemantics
+from .rewriters import (
+    MojoDictKeysInElider,
+    MojoImplicitConstructor,
+    MojoInferMoveSemantics,
+)
 from .transpiler import MojoTranspiler
 
 
@@ -15,7 +19,7 @@ def settings(args, env=os.environ):
         "Mojo",
         ["mojo", "format"],
         None,
-        [MojoInferMoveSemantics()],
+        [MojoDictKeysInElider(), MojoInferMoveSemantics()],
         [infer_mojo_types],
         post_rewriters=[
             MojoImplicitConstructor(),

--- a/pymojo/plugins.py
+++ b/pymojo/plugins.py
@@ -21,8 +21,8 @@ class MojoTranspilerPlugins:
 SMALL_DISPATCH_MAP = {
     "str": lambda n, vargs: f"$({vargs[0]})" if vargs else '""',
     "bool": lambda n, vargs: f"bool({vargs[0]})" if vargs else "False",
-    "int": lambda n, vargs: f"int({vargs[0]})" if vargs else "0",
-    "floor": lambda n, vargs: f"int(floor({vargs[0]}))",
+    "int": lambda n, vargs: f"Int({vargs[0]})" if vargs else "0",
+    "floor": lambda n, vargs: f"Int(floor({vargs[0]}))",
     "float": functools.partial(MojoTranspilerPlugins.visit_cast, cast_to="Float64"),
 }
 
@@ -34,7 +34,7 @@ DISPATCH_MAP = {
 
 MODULE_DISPATCH_TABLE: Dict[str, str] = {}
 
-DECORATOR_DISPATCH_TABLE = {"dataclass": lambda n, vargs: "value"}
+DECORATOR_DISPATCH_TABLE = {"dataclass": lambda n, vargs: "fieldwise_init"}
 
 CLASS_DISPATCH_TABLE: Dict[type, Callable] = {}
 

--- a/pymojo/rewriters.py
+++ b/pymojo/rewriters.py
@@ -24,6 +24,34 @@ class MojoImplicitConstructor(ast.NodeTransformer):
         return node
 
 
+class MojoDictKeysInElider(ast.NodeTransformer):
+    """Rewrite `x in d.keys()` to `x in d`.
+
+    Mojo's `Dict.keys()` returns `_DictKeyIter`, which doesn't implement
+    `__contains__`. In Python both forms are equivalent for dicts, so dropping
+    the `.keys()` call is semantics-preserving and lets the emission go through
+    Mojo's `Dict.__contains__`.
+    """
+
+    def visit_Compare(self, node):
+        self.generic_visit(node)
+        if (
+            len(node.ops) == 1
+            and isinstance(node.ops[0], ast.In)
+            and len(node.comparators) == 1
+        ):
+            rhs = node.comparators[0]
+            if (
+                isinstance(rhs, ast.Call)
+                and isinstance(rhs.func, ast.Attribute)
+                and rhs.func.attr == "keys"
+                and not rhs.args
+                and not rhs.keywords
+            ):
+                node.comparators = [rhs.func.value]
+        return node
+
+
 class MojoInferMoveSemantics(ast.NodeTransformer):
     def __init__(self):
         super().__init__()

--- a/pymojo/transpiler.py
+++ b/pymojo/transpiler.py
@@ -46,7 +46,12 @@ class MojoTranspiler(CLikeTranspiler):
 
     def usings(self):
         usings = sorted(list(set(self._usings)))
-        uses = "\n".join(f"import {mod}" for mod in usings)
+        # Entries that already begin with "from " are emitted verbatim so callers
+        # (e.g. visit_Assert -> "from testing import assert_true") can specify
+        # `from X import Y` instead of a bare `import X`.
+        uses = "\n".join(
+            mod if mod.startswith("from ") else f"import {mod}" for mod in usings
+        )
         return uses
 
     @classmethod
@@ -74,7 +79,7 @@ class MojoTranspiler(CLikeTranspiler):
             if node.name == "__init__" and arg == "self":
                 arg = "out " + arg
             elif getattr(arg_node, "owned", None):
-                arg = "owned " + arg
+                arg = "var " + arg
 
             args_list.append(f"{arg}: {typename}")
 
@@ -168,10 +173,26 @@ class MojoTranspiler(CLikeTranspiler):
         if isinstance(fndef, ast.ClassDef):
             return self._visit_object_literal(node, fname, fndef)
 
+        # For obj.method(args), fndef.args.args[0] is self, so the i-th
+        # positional caller arg corresponds to fndef.args.args[i+1].
+        fn_args = fndef.args.args if isinstance(fndef, ast.FunctionDef) else []
+        arg_offset = (
+            1
+            if isinstance(node.func, ast.Attribute)
+            and fn_args
+            and getattr(fn_args[0], "arg", None) == "self"
+            else 0
+        )
+
         vargs = []
 
         if node.args:
-            vargs += [self.visit(a) for a in node.args]
+            for i, a in enumerate(node.args):
+                s = self.visit(a)
+                j = i + arg_offset
+                if j < len(fn_args) and getattr(fn_args[j], "owned", None):
+                    s = f"{s}^"
+                vargs.append(s)
         if node.keywords:
             vargs += [self.visit(kw.value) for kw in node.keywords]
 
@@ -296,7 +317,10 @@ class MojoTranspiler(CLikeTranspiler):
             if isinstance(b, ast.FunctionDef):
                 b.self_type = node.name
 
-        struct_def = f"{mojo_decorators}struct {node.name}:\n"
+        struct_traits = (
+            "(Copyable, Movable)" if "@fieldwise_init" in mojo_decorators else ""
+        )
+        struct_def = f"{mojo_decorators}struct {node.name}{struct_traits}:\n"
         struct_def += "\n".join([self.indent(f, level=node.level + 1) for f in fields])
         struct_def += "\n"
         for b in node.body:
@@ -347,8 +371,22 @@ class MojoTranspiler(CLikeTranspiler):
         fields = "\n".join([self.indent(f) for f in fields])
         return f"type {node.name} = enum\n{fields}\n\n"
 
+    # Mojo deprecates bare `import math` / `from testing import …` in 0.26+ and
+    # will make them an error; the compiler wants every stdlib reference to be
+    # fully qualified with `std.`. Prepend it for modules we know are part of
+    # mojo's stdlib so the emitted code stays warning-clean.
+    _MOJO_STDLIB_MODULES = frozenset({"testing", "math"})
+
+    @classmethod
+    def _qualify_stdlib(cls, module_name: str) -> str:
+        return (
+            f"std.{module_name}"
+            if module_name in cls._MOJO_STDLIB_MODULES
+            else module_name
+        )
+
     def _import(self, name: str) -> str:
-        return f"import {name}"
+        return f"import {self._qualify_stdlib(name)}"
 
     def _import_from(self, module_name: str, names: List[str], level: int = 0) -> str:
         names = ", ".join(names)
@@ -358,13 +396,15 @@ class MojoTranspiler(CLikeTranspiler):
             lookup = f"{module_name}.{name}"
             if lookup in MODULE_DISPATCH_TABLE:
                 mojo_module_name, mojo_name = MODULE_DISPATCH_TABLE[lookup]
-                return f"from {mojo_module_name} import {mojo_name}"
-        return f"from {module_name} import {names}"
+                return (
+                    f"from {self._qualify_stdlib(mojo_module_name)} import {mojo_name}"
+                )
+        return f"from {self._qualify_stdlib(module_name)} import {names}"
 
     def visit_List(self, node) -> str:
         elements = [self.visit(e) for e in node.elts]
         elements = ", ".join(elements)
-        return f"List({elements})"
+        return f"[{elements}]"
 
     def visit_Set(self, node) -> str:
         self._usings.add("sets")
@@ -410,8 +450,8 @@ class MojoTranspiler(CLikeTranspiler):
         return f"({elts})"
 
     def visit_Assert(self, node) -> str:
-        self._usings.add("testing")
-        return f"testing.assert_true({self.visit(node.test)})"
+        self._usings.add("from std.testing import assert_true")
+        return f"assert_true({self.visit(node.test)})"
 
     def visit_AnnAssign(self, node) -> str:
         target, type_str, val = super().visit_AnnAssign(node)

--- a/tests/dir_cases/test1-mojo-expected/foo.mojo
+++ b/tests/dir_cases/test1-mojo-expected/foo.mojo
@@ -1,4 +1,4 @@
-import testing
+from std.testing import assert_true
 from bar import bar1
 from baz import baz1
 
@@ -6,5 +6,5 @@ from baz import baz1
 fn main() raises:
     var x = bar1()
     var y = baz1()
-    testing.assert_true(x == 0)
-    testing.assert_true(y == "foo")
+    assert_true(x == 0)
+    assert_true(y == "foo")

--- a/tests/expected/assert.mojo
+++ b/tests/expected/assert.mojo
@@ -1,15 +1,15 @@
-import testing
+from std.testing import assert_true
 
 
 fn compare_assert(a: Int, b: Int) raises:
-    testing.assert_true(a == b)
-    testing.assert_true(not (0 == 1))
+    assert_true(a == b)
+    assert_true(not (0 == 1))
 
 
 fn main() raises:
-    testing.assert_true(True)
-    testing.assert_true(not (False))
+    assert_true(True)
+    assert_true(not (False))
     compare_assert(1, 1)
-    testing.assert_true(True)
-    testing.assert_true(True)
+    assert_true(True)
+    assert_true(True)
     print("OK")

--- a/tests/expected/bubble_sort.mojo
+++ b/tests/expected/bubble_sort.mojo
@@ -1,7 +1,7 @@
-import testing
+from std.testing import assert_true
 
 
-fn bubble_sort(owned seq: List[Int]) -> List[Int]:
+fn bubble_sort(var seq: List[Int]) -> List[Int]:
     var L = len(seq)
     for _ in range(L):
         for n in range(1, L):
@@ -12,7 +12,7 @@ fn bubble_sort(owned seq: List[Int]) -> List[Int]:
 
 
 fn main() raises:
-    var unsorted = List(14, 11, 19, 5, 16, 10, 19, 12, 5, 12)
-    var expected = List(5, 5, 10, 11, 12, 12, 14, 16, 19, 19)
-    testing.assert_true(bubble_sort(unsorted) == expected)
+    var unsorted = [14, 11, 19, 5, 16, 10, 19, 12, 5, 12]
+    var expected = [5, 5, 10, 11, 12, 12, 14, 16, 19, 19]
+    assert_true(bubble_sort(unsorted^) == expected)
     print("OK")

--- a/tests/expected/built_ins.mojo
+++ b/tests/expected/built_ins.mojo
@@ -1,4 +1,4 @@
-import testing
+from std.testing import assert_true
 
 
 fn default_builtins() raises:
@@ -6,10 +6,10 @@ fn default_builtins() raises:
     var b = False
     var c = 0
     var d = 0.0
-    testing.assert_true(a == "")
-    testing.assert_true(b == False)
-    testing.assert_true(c == 0)
-    testing.assert_true(d == 0.0)
+    assert_true(a == "")
+    assert_true(b == False)
+    assert_true(c == 0)
+    assert_true(d == 0.0)
 
 
 fn main():
@@ -17,5 +17,5 @@ fn main():
     print(a)
     var b = min(1, 2)
     print(b)
-    var c = int(min(1.0, 2.0))
+    var c = Int(min(1.0, 2.0))
     print(c)

--- a/tests/expected/classes.mojo
+++ b/tests/expected/classes.mojo
@@ -1,4 +1,4 @@
-import testing
+from std.testing import assert_true
 
 
 struct Foo:
@@ -16,4 +16,4 @@ fn main() raises:
     var f = Foo()
     var b = f.bar()
     print(b)
-    testing.assert_true(b == 10)
+    assert_true(b == 10)

--- a/tests/expected/comb_sort.mojo
+++ b/tests/expected/comb_sort.mojo
@@ -1,12 +1,12 @@
-import testing
-from math import floor
+from std.testing import assert_true
+from std.math import floor
 
 
-fn comb_sort(owned seq: List[Int]) -> List[Int]:
+fn comb_sort(var seq: List[Int]) -> List[Int]:
     var gap = len(seq)
     var swap = True
     while gap > 1 or swap:
-        gap = max(1, int(floor((gap / 1.25))))
+        gap = max(1, Int(floor((gap / 1.25))))
         swap = False
         for i in range((len(seq) - gap)):
             if seq[i] > seq[(i + gap)]:
@@ -17,7 +17,7 @@ fn comb_sort(owned seq: List[Int]) -> List[Int]:
 
 
 fn main() raises:
-    var unsorted = List(14, 11, 19, 5, 16, 10, 19, 12, 5, 12)
-    var expected = List(5, 5, 10, 11, 12, 12, 14, 16, 19, 19)
-    testing.assert_true(comb_sort(unsorted) == expected)
+    var unsorted = [14, 11, 19, 5, 16, 10, 19, 12, 5, 12]
+    var expected = [5, 5, 10, 11, 12, 12, 14, 16, 19, 19]
+    assert_true(comb_sort(unsorted^) == expected)
     print("OK")

--- a/tests/expected/comparison.mojo
+++ b/tests/expected/comparison.mojo
@@ -1,4 +1,4 @@
-import testing
+from std.testing import assert_true
 
 
 fn compare_with_integer_variable() raises:
@@ -8,7 +8,7 @@ fn compare_with_integer_variable() raises:
         s = 2
     else:
         s = 3
-    testing.assert_true(s == 3)
+    assert_true(s == 3)
 
 
 fn use_zero_for_comparison() raises:
@@ -18,7 +18,7 @@ fn use_zero_for_comparison() raises:
         s = 2
     else:
         s = 3
-    testing.assert_true(s == 3)
+    assert_true(s == 3)
 
 
 fn main() raises:

--- a/tests/expected/dict.mojo
+++ b/tests/expected/dict.mojo
@@ -1,4 +1,4 @@
-import testing
+from std.testing import assert_true
 
 
 fn implicit_keys() -> Bool:
@@ -8,7 +8,7 @@ fn implicit_keys() -> Bool:
 
 fn explicit_keys() -> Bool:
     var CODES = {"KEY": 1}
-    return "KEY" in CODES.keys()
+    return "KEY" in CODES
 
 
 fn dict_values() -> Bool:
@@ -27,9 +27,9 @@ fn return_dict_index_int(key: Int) -> String:
 
 
 fn main() raises:
-    testing.assert_true(implicit_keys())
-    testing.assert_true(explicit_keys())
-    testing.assert_true(dict_values())
-    testing.assert_true(return_dict_index_str("KEY") == 1)
-    testing.assert_true(return_dict_index_int(1) == "one")
+    assert_true(implicit_keys())
+    assert_true(explicit_keys())
+    assert_true(dict_values())
+    assert_true(return_dict_index_str("KEY") == 1)
+    assert_true(return_dict_index_int(1) == "one")
     print("OK")

--- a/tests/expected/infer.mojo
+++ b/tests/expected/infer.mojo
@@ -1,10 +1,10 @@
-import testing
+from std.testing import assert_true
 
 
 fn foo() raises:
     var a = 10
     var b = a
-    testing.assert_true(b == 10)
+    assert_true(b == 10)
     print(b)
 
 

--- a/tests/expected/rect.mojo
+++ b/tests/expected/rect.mojo
@@ -1,10 +1,10 @@
-import testing
+from std.testing import assert_true
 
 # This file implements a rectangle class
 
 
-@value
-struct Rectangle:
+@fieldwise_init
+struct Rectangle(Copyable, Movable):
     var height: Int
     var length: Int
 
@@ -14,9 +14,9 @@ struct Rectangle:
 
 fn show() raises:
     var r = Rectangle(height=1, length=1)
-    testing.assert_true(r.is_square())
+    assert_true(r.is_square())
     r = Rectangle(height=1, length=2)
-    testing.assert_true(not (r.is_square()))
+    assert_true(not (r.is_square()))
     print(r.height)
     print(r.length)
 


### PR DESCRIPTION
With this change, only dict.mojo still fails:

````
SKIPPED [1] test_cli.py:298: dict.mojo doesnt compile
````
https://github.com/jayvdb/py2many/actions/runs/26552107473/job/78216176810