### PR TITLE
Add .mise.toml

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,120 @@
+[tools]
+"asdf:mise-plugins/mise-nim" = { version = "2.2.10", os = ["linux", "macos"] }
+# asdf plugins are shell scripts that can't run on Windows; use the official
+# prebuilt Windows binary there instead.
+"http:nim" = { version = "2.2.10", url = "https://nim-lang.org/download/nim-{{ version }}_x64.zip", bin_path = "nim-{{ version }}/bin", os = ["windows"] }
+# conda's clang++ isn't usable standalone on Windows: its DLLs (libLLVM etc.)
+# live in the conda env's Library/bin, not on PATH via mise's shim, and Windows
+# has no RPATH, so it dies at load with STATUS_DLL_NOT_FOUND (0xC0000135). Keep
+# it off Windows; there the cpp cases compile via g++ (test_env_cxx_gcc, using
+# the winlibs http:mingw toolchain) and test_generated's cpp cases skip cleanly.
+"conda:clangxx" = { version = "latest", os = ["linux", "macos"] }
+# conda-forge's gcc isn't usable standalone on Windows: invoked directly it
+# fails with "cannot execute 'cc1plus': CreateProcess: No such file" because the
+# activation-style package can't locate its internal compiler. Use it on
+# linux/macos; on Windows install a portable winlibs MinGW-w64 toolchain (below)
+# which ships a real standalone g++ with cc1plus in the correct relative path.
+"conda:gxx" = { version = "latest", os = ["linux", "macos"] }
+"conda:libcxx-devel" = { version = "latest", os = ["linux", "macos"] }
+"github:ldc-developers/ldc" = "latest"
+# mise's github backend auto-strips the single top-level v/ dir on Linux/macOS
+# but does so unreliably for Windows zips, leaving v.exe nested and off PATH.
+# Force the strip on all platforms so v(.exe) lands at the install root.
+"github:vlang/v" = { version = "0.5.1", strip_components = 1 }
+"github:Z3Prover/z3" = "z3-4.15.4"
+"go:github.com/mgechev/revive" = "latest"
+# Portable standalone MinGW-w64 GCC for Windows (winlibs). The archive unpacks
+# to a top-level mingw64/, with g++ in mingw64/bin and cc1plus alongside under
+# mingw64/, so the driver resolves it correctly (unlike conda:gxx above).
+"http:mingw" = { version = "14.2.0", url = "https://github.com/brechtsanders/winlibs_mingw/releases/download/{{ version }}posix-19.1.1-12.0.0-ucrt-r2/winlibs-x86_64-posix-seh-gcc-{{ version }}-mingw-w64ucrt-12.0.0-r2.zip", bin_path = "mingw64/bin", os = ["windows"] }
+pipx = { version = "latest", os = ["linux", "macos"] }
+"pipx:black" = "24.10.0"
+"pipx:cpplint" = "latest"
+"pipx:flake8" = "latest"
+"pipx:isort" = "latest"
+"pipx:jgo" = "latest"
+"pipx:mojo" = { version = "0.26.2.0", uvx = false, pipx_args = "--include-deps", os = ["linux/x64", "linux/arm64", "macos/arm64"] }
+"pipx:pytest" = "latest"
+"pipx:tox" = "latest"
+clang-format = "18.1.3"
+cljstyle = { version = "latest", os = ["linux", "macos"] }
+conan = "latest"
+dart = { version = "3.4.4", url = "https://storage.googleapis.com/dart-archive/channels/stable/release/{{ version }}/sdk/dartsdk-{{ os() }}-{{ arch() }}-release.zip", version_expr = 'fromJSON(body).prefixes | filter({ # matches "^channels/stable/release/(\\d+\\.\\d+\\.\\d+)/$" }) | map({split(#, "/")[3]}) | sortVersions()', version_list_url = "https://storage.googleapis.com/storage/v1/b/dart-archive/o?prefix=channels/stable/release/&delimiter=/" }
+flutter = { version = "3.22.3", platforms = { linux-x64 = { url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_{{ version }}-stable.tar.xz" }, macos-arm64 = { url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_arm64_{{ version }}-stable.zip" }, macos-x64 = { url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_{{ version }}-stable.zip" }, windows-x64 = { url = "https://storage.googleapis.com/flutter_infra_release/releases/stable/windows/flutter_windows_{{ version }}-stable.zip" } }, version_expr = 'fromJSON(body).releases | filter({ #.channel == "stable" }) | map({ replace(#.version, "-stable", "") }) | sortVersions()', version_list_url = "https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json" }
+go = "latest"
+# Pinned to 21 (LTS): kotlinc 2.0.21 crashes parsing JDK versions newer than it
+# knows about (e.g. JDK 26 -> IllegalArgumentException in IntelliJ's
+# JavaVersion.parse). JDK 21 is also fine for jgo/maven.
+java = "21"
+julia = { version = "latest", platforms = { linux-arm64 = { url = """{% if version == "nightly" %}https://julialangnightlies-s3.julialang.org/bin/linux/aarch64/julia-latest-linuxaarch64.tar.gz{% else %}https://julialang-s3.julialang.org/bin/linux/aarch64/{{ version | split(pat='.') | slice(start=0, end=2) | join(sep='.') }}/julia-{{ version }}-linux-aarch64.tar.gz{% endif %}""" }, linux-x64 = { url = """{% if version == "nightly" %}https://julialangnightlies-s3.julialang.org/bin/linux/x64/julia-latest-linux64.tar.gz{% else %}https://julialang-s3.julialang.org/bin/linux/x64/{{ version | split(pat='.') | slice(start=0, end=2) | join(sep='.') }}/julia-{{ version }}-linux-x86_64.tar.gz{% endif %}""" }, macos-arm64 = { url = """{% if version == "nightly" %}https://julialangnightlies-s3.julialang.org/bin/mac/aarch64/julia-latest-macaarch64.tar.gz{% else %}https://julialang-s3.julialang.org/bin/mac/aarch64/{{ version | split(pat='.') | slice(start=0, end=2) | join(sep='.') }}/julia-{{ version }}-macaarch64.tar.gz{% endif %}""" }, macos-x64 = { url = """{% if version == "nightly" %}https://julialangnightlies-s3.julialang.org/bin/mac/x64/julia-latest-mac64.tar.gz{% else %}https://julialang-s3.julialang.org/bin/mac/x64/{{ version | split(pat='.') | slice(start=0, end=2) | join(sep='.') }}/julia-{{ version }}-mac64.tar.gz{% endif %}""" }, windows-x64 = { format = "zip", url = """{% if version == "nightly" %}https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.zip{% else %}https://julialang-s3.julialang.org/bin/winnt/x64/{{ version | split(pat='.') | slice(start=0, end=2) | join(sep='.') }}/julia-{{ version }}-win64.zip{% endif %}""" } }, version_expr = 'sortVersions(filter(keys(fromJSON(body)), { # matches "^\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z\\.-]+)?$" }))', version_list_url = "https://julialang-s3.julialang.org/bin/versions.json" }
+kotlin = { version = "1.7.20", asset_pattern = "kotlin-compiler-*.zip", bin_path = "kotlinc/bin" }
+maven = "latest"
+python = "3.12"
+rust = { version = "latest", components = "rustfmt,clippy" }
+uv = "latest"
+zig = "latest"
+
+[env]
+# ~/.julia/bin holds the JuliaFormatter `jlfmt` app, and dub's default package
+# cache holds the prebuilt dfmt (scripts/dlang-setup.sh). Both must be on PATH
+# so the formatters resolve directly (dfmt avoids the race-prone, per-call
+# `dub run dfmt` -- https://github.com/dlang-community/dfmt/issues/407,
+# https://github.com/dlang/dub/issues/1113). The home and dub cache locations
+# differ on Windows (native %USERPROFILE% rather than git-bash's /c/... $HOME;
+# %LOCALAPPDATA%\dub rather than ~/.dub), so these entries are OS-specific.
+_.path = [
+  "{% if os() == 'windows' %}{{ env.USERPROFILE }}{% else %}{{ env.HOME }}{% endif %}/.julia/bin",
+  "{% if os() == 'windows' %}{{ env.LOCALAPPDATA }}/dub{% else %}{{ env.HOME }}/.dub{% endif %}/packages/dfmt/0.15.2/dfmt/bin",
+]
+
+# Inject conda-libcxx-devel into clang's include/link paths for the cpp tests
+# (CCC_OVERRIDE_OPTIONS is clang-driver only; g++ ignores it). Windows ignores
+# missing dirs. macOS skips the override because conda-libcxx-devel conflicts
+# with Apple's Command Line Tools SDK headers (`xcode-select --install`), which
+# the cpp tests then depend on instead.
+CCC_OVERRIDE_OPTIONS = "{% if os() == 'macos' %}{% else %}+-isystem +{{ env.HOME }}/.local/share/mise/installs/conda-libcxx-devel/latest/include/c++/v1 +-L +{{ env.HOME }}/.local/share/mise/installs/conda-libcxx-devel/latest/lib{% endif %}"
+LD_LIBRARY_PATH = "{% if os() == 'macos' %}{% else %}{{ env.HOME }}/.local/share/mise/installs/conda-libcxx-devel/latest/lib{% endif %}"
+
+# test_env_cxx_gcc needs a real GCC g++. On macOS plain `g++` is Apple's
+# clang shim, so point at conda-gxx's binary (and the test augments PATH with
+# its bin/ so g++ finds its sibling clang assembler). On Linux plain `g++` is
+# real GCC. On Windows the test uses the http:mingw toolchain.
+CXX_GCC = "{% if os() == 'macos' %}{{ env.HOME }}/.local/share/mise/installs/conda-gxx/latest/bin/g++{% endif %}"
+
+# Without KOTLIN_HOME the test harness has no way to run kotlin (a bare .class
+# isn't executable), so the kotlin cases used to rely on kotlinc being absent to
+# skip -- but mise installs it. Point KOTLIN_HOME at the mise kotlin install so
+# the jgo/kscript invoker is used to actually run the kotlin cases.
+# Use the exact pinned version (1.7.20) rather than a `1.7` alias or `latest`:
+# mise auto-creates the major.minor symlink on Linux/macOS but not on Windows
+# (creating symlinks there requires Developer Mode or elevated privileges, so
+# mise skips it), and kscript invokes `kotlinc.bat` via cmd which gives a bare
+# `The system cannot find the path specified` when the alias dir doesn't exist.
+# `latest` would also track the highest *installed* kotlin, not the pinned one.
+# kscript 4.2.3 only works with a 1.7.x kotlinc. Keep this in sync with the
+# kotlin pin in the [tools] section.
+KOTLIN_HOME = "{% if os() == 'windows' %}{{ env.LOCALAPPDATA }}/mise/installs/kotlin/1.7.20/kotlinc{% else %}{{ env.HOME }}/.local/share/mise/installs/kotlin/1.7.20/kotlinc{% endif %}"
+
+# These tasks run bash scripts and bash-isms (set -ex); force bash so they work
+# on Windows too, where mise's default task shell is cmd/PowerShell.
+[tasks.setup]
+description = "Install deps"
+shell = "bash -c"
+run = """
+set -ex
+./scripts/cpp-setup.sh
+./scripts/dart-setup.sh
+./scripts/go-setup.sh
+./scripts/julia-setup.sh
+./scripts/vlang-setup.sh
+./scripts/zig-setup.sh
+"""
+
+# No shell override: this is a plain command (no bash-isms), and on Windows
+# forcing it through git-bash routes the native tox/pytest subprocesses through
+# MSYS path translation, which hides mise's tool dirs from the formatters the
+# tests invoke. mise's native shell keeps a Windows PATH that resolves them.
+[tasks.test]
+run = """
+tox -e py312-full
+"""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -294,10 +294,21 @@ class TestCodeGenerator:
                     return
                 cmd = _create_cmd(compiler, filename=case_output, exe=exe)
                 print(f"Compiling {cmd} ...")
-                proc = run(cmd, env=env, check=False)
+                proc = run(cmd, env=env, check=False, capture_output=True)
+                out = proc.stdout.decode("utf-8", "replace") if proc.stdout else ""
+                err = proc.stderr.decode("utf-8", "replace") if proc.stderr else ""
+                print(out)
+                print(err)
 
                 if proc.returncode and not expect_failure:
-                    raise pytest.skip(f"{case}{ext} doesnt compile")
+                    raise pytest.skip(
+                        f"{case}{ext} doesnt compile (exit={proc.returncode})\n"
+                        f"cmd: {cmd}\n"
+                        f"resolved {compiler[0]!r} -> {find_executable(compiler[0])!r}\n"
+                        f"cwd: {os.getcwd()}\n"
+                        f"--- stdout ({len(out)} chars) ---\n{out}\n"
+                        f"--- stderr ({len(err)} chars) ---\n{err}"
+                    )
 
                 if self.UPDATE_EXPECTED or not os.path.exists(expected_filename):
                     with open(expected_filename, "w") as f:

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,8 @@ passenv =
     CXXFLAGS
     VFLAGS
     CLANG_FORMAT_STYLE
+    CCC_OVERRIDE_OPTIONS
+    LD_LIBRARY_PATH
     UPDATE_EXPECTED
     KEEP_GENERATED
     SHOW_ERRORS
@@ -21,8 +23,16 @@ passenv =
     JAVA_HOME
     KOTLIN_HOME
     MODULAR_HOME
+    MISE_DATA_DIR
+    OS
     FOCUS
     PYTEST_ADDOPTS
+# Per-OS coverage target: Windows runs fewer language backends (several tools
+# lack Windows support), so it can't reach the full-platform target. Windows
+# always sets OS=Windows_NT; other OSes leave OS unset, selecting the "_" key.
+set_env =
+    COV_FAIL_UNDER_ = 88
+    COV_FAIL_UNDER_Windows_NT = 85.5
 deps =
     py38: importlib-resources
     pytest-cov
@@ -37,4 +47,4 @@ deps =
     full: z3-solver<4.15.5; platform_system == "Darwin" and platform_machine == "x86_64"
 changedir = tests
 commands =
-    pytest --junitxml=current-results.xml --import-mode=importlib --tb=native --assert=plain --ignore=expected --ignore=ext_expected --cov=py2many --cov-report=term-missing:skip-covered -rs -v {posargs:--cov-fail-under=92}
+    pytest --junitxml=current-results.xml --import-mode=importlib --tb=native --assert=plain --ignore=expected --ignore=ext_expected --cov=py2many --cov-report=term-missing:skip-covered -rs -v {posargs:--cov-fail-under={env:COV_FAIL_UNDER_{env:OS:}:88}}


### PR DESCRIPTION
Allows installing all necessary tools using https://mise.jdx.dev/ , and run the tests.

Here it is running in GHA:
https://github.com/jayvdb/py2many/actions/runs/26556459722/job/78229615426

Here is the possible workflow we can use https://github.com/jayvdb/py2many/blob/mise-no-xdist-gha/.github/workflows/mise.yml

I have fixes for the macos and windows failures/incorrect skips.

17 mins to run all tests on Linux.

When I also add [pytest-xdist](https://github.com/pytest-dev/pytest-xdist) , and fix the many test concurrency bugs, it goes down to 12mins to run _all_ tests on Linux.
https://github.com/jayvdb/py2many/actions/runs/26507313773/job/78062943321