### PR TITLE
Fix _run on Windows

### DIFF
--- a/py2many/cli.py
+++ b/py2many/cli.py
@@ -216,7 +216,9 @@ def _run(cmd, **kwargs):
     .sh scripts (e.g. the rust/zig runners) through Git-for-Windows' bash."""
 
     if cmd and sys.platform == "win32":
-        argv0 = cmd[0].lower()
+        # cmd[0] may be a pathlib.Path (test rig passes compiled-exe paths) --
+        # coerce to str before the extension check so .lower() doesn't blow up.
+        argv0 = str(cmd[0]).lower()
         if argv0.endswith((".bat", ".cmd")):
             cmd = ["cmd", "/c", *cmd]
         elif argv0.endswith(".sh"):


### PR DESCRIPTION
Followup to https://github.com/py2many/py2many/pull/798

Windows green at https://github.com/jayvdb/py2many/actions/runs/26621023936/job/78446731118 running _all_ tests.