### PR TITLE
Add C++ AST render pass

### DIFF
--- a/.github/workflows/fast.yaml
+++ b/.github/workflows/fast.yaml
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install linters
-        run: pip install black==24.10.0 cpplint isort flake8
+        run: pip install black==24.10.0 cpplint isort==5.13.2 flake8
 
       - name: Remove expected .py files
         run: rm tests/expected/*.py tests/dir_cases/test1-*-expected/*.py

--- a/.github/workflows/main-hosted.yml
+++ b/.github/workflows/main-hosted.yml
@@ -270,7 +270,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install linters
-        run: pip install black==24.10.0 cpplint isort flake8
+        run: pip install black==24.10.0 cpplint isort==5.13.2 flake8
 
       - name: Remove expected .py files
         run: rm tests/expected/*.py tests/dir_cases/test1-*-expected/*.py

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -89,7 +89,7 @@ RUN python3 -m venv "${HOME}/.venv" \
       conan \
       cpplint \
       flake8 \
-      isort \
+      isort==5.13.2 \
       jgo \
       setuptools \
       tox

--- a/docker/Dockerfile.omni
+++ b/docker/Dockerfile.omni
@@ -106,7 +106,7 @@ RUN python3 -m venv "${HOME}/.venv" \
       conan \
       cpplint \
       flake8 \
-      isort \
+      isort==5.13.2 \
       "jgo<2" \
       setuptools \
       tox

--- a/pycpp/cpp_ast.py
+++ b/pycpp/cpp_ast.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Protocol
+
+
+class CppRenderable(Protocol):
+    def render(self) -> str: ...
+
+
+def _load_tree_sitter_cpp():
+    try:
+        import tree_sitter_cpp
+        from tree_sitter import Language, Parser
+    except ImportError:
+        return None
+
+    parser = Parser()
+    cpp_language = tree_sitter_cpp.language()
+    try:
+        language = Language(cpp_language)
+    except TypeError:
+        language = cpp_language
+
+    if hasattr(parser, "set_language"):
+        parser.set_language(language)
+    else:
+        parser.language = language
+    return parser
+
+
+def _node_has_error(node) -> bool:
+    if getattr(node, "has_error", False):
+        return True
+    return any(_node_has_error(child) for child in node.children)
+
+
+@dataclass(frozen=True)
+class CppTreeSitterNode:
+    """A C++ syntax subtree parsed by tree-sitter."""
+
+    source: str
+    kind: str = "translation_unit"
+    has_error: bool = False
+    _tree: object | None = field(default=None, repr=False, compare=False)
+
+    @classmethod
+    def parse(cls, source: str) -> "CppTreeSitterNode":
+        parser = _load_tree_sitter_cpp()
+        if parser is None:
+            return cls(source=source)
+
+        tree = parser.parse(source.encode("utf-8"))
+        root = tree.root_node
+        return cls(
+            source=source,
+            kind=root.type,
+            has_error=_node_has_error(root),
+            _tree=tree,
+        )
+
+    @property
+    def tree(self):
+        return self._tree
+
+    def render(self) -> str:
+        return self.source
+
+
+class CppNode(str):
+    """A C++ syntax fragment backed by a tree-sitter parse.
+
+    The C++ transpiler still has expression-level composition logic that expects
+    string operations. Subclassing str lets that logic keep working while
+    visitors move toward returning renderable C++ nodes.
+    """
+
+    node: CppTreeSitterNode
+
+    def __new__(cls, source: str | CppRenderable) -> "CppNode":
+        if isinstance(source, CppNode):
+            return source
+        source_str = source.render() if hasattr(source, "render") else str(source)
+        obj = str.__new__(cls, source_str)
+        obj.node = CppTreeSitterNode.parse(source_str)
+        return obj
+
+    @property
+    def tree(self):
+        return self.node.tree
+
+    @property
+    def kind(self) -> str:
+        return self.node.kind
+
+    @property
+    def has_error(self) -> bool:
+        return self.node.has_error
+
+    def render(self) -> str:
+        return str(self)
+
+
+class CppCall(CppNode):
+    def __new__(
+        cls,
+        function: str | CppRenderable,
+        args: Iterable[str | CppRenderable],
+    ) -> "CppCall":
+        rendered_args = ", ".join(str(arg) for arg in args)
+        return super().__new__(cls, f"{function}({rendered_args})")
+
+
+class CppReturn(CppNode):
+    def __new__(cls, value: str | CppRenderable | None = None) -> "CppReturn":
+        if value is None:
+            return super().__new__(cls, "return;")
+        return super().__new__(cls, f"return {value};")
+
+
+class CppAssignment(CppNode):
+    def __new__(
+        cls, target: str | CppRenderable, value: str | CppRenderable
+    ) -> "CppAssignment":
+        return super().__new__(cls, f"{target} = {value};")
+
+
+class CppAugAssignment(CppNode):
+    def __new__(
+        cls,
+        target: str | CppRenderable,
+        op: str | CppRenderable,
+        value: str | CppRenderable,
+    ) -> "CppAugAssignment":
+        return super().__new__(cls, f"{target} {op}= {value};")
+
+
+class CppDeclaration(CppNode):
+    def __new__(
+        cls,
+        typename: str | CppRenderable,
+        target: str | CppRenderable,
+        value: str | CppRenderable,
+        suffix: str = "",
+    ) -> "CppDeclaration":
+        return super().__new__(cls, f"{typename} {target} = {value};{suffix}")
+
+
+class CppExprStatement(CppNode):
+    def __new__(cls, expression: str | CppRenderable) -> "CppExprStatement":
+        rendered = str(expression).strip()
+        if not rendered.endswith(";"):
+            rendered += ";"
+        return super().__new__(cls, rendered)
+
+
+class CppFunction(CppNode):
+    def __new__(
+        cls,
+        signature: str | CppRenderable,
+        body: Iterable[str | CppRenderable],
+    ) -> "CppFunction":
+        rendered_body = "\n".join(str(item) for item in body)
+        return super().__new__(cls, f"{signature} {{\n{rendered_body}\n}}\n")
+
+
+@dataclass(frozen=True)
+class CppRawItem:
+    """A C++ item or statement subtree kept as source until visitors are typed."""
+
+    node: CppTreeSitterNode
+
+    @classmethod
+    def from_source(cls, source: str) -> "CppRawItem":
+        if isinstance(source, CppNode):
+            return cls(source.node)
+        return cls(CppTreeSitterNode.parse(source))
+
+    def render(self) -> str:
+        return self.node.render()
+
+
+@dataclass(frozen=True)
+class CppSourceFile:
+    items: tuple
+
+    @classmethod
+    def from_items(cls, items: Iterable[str | CppRenderable]) -> "CppSourceFile":
+        renderable_items: list[CppRenderable] = []
+        for item in items:
+            if hasattr(item, "render"):
+                renderable_items.append(item)
+            elif isinstance(item, str):
+                if item:
+                    renderable_items.append(CppRawItem.from_source(item))
+            else:
+                renderable_items.append(CppNode(str(item)))
+        return cls(tuple(renderable_items))
+
+    def render(self) -> str:
+        rendered_items = []
+        for item in self.items:
+            rendered = item.render()
+            rendered = rendered.rstrip("\n") + ("\n" if rendered.endswith("\n") else "")
+            rendered_items.append(rendered)
+        return "\n".join(rendered_items)
+
+
+class CppRenderer:
+    def render(self, node: CppRenderable) -> str:
+        return node.render()

--- a/pycpp/transpiler.py
+++ b/pycpp/transpiler.py
@@ -1,5 +1,6 @@
 import ast
 import textwrap
+from pathlib import Path
 from typing import List, Tuple
 
 from py2many.analysis import add_imports, get_id, is_global, is_void_function
@@ -20,6 +21,18 @@ from py2many.tracer import (
 )
 
 from .clike import CLikeTranspiler
+from .cpp_ast import (
+    CppAssignment,
+    CppAugAssignment,
+    CppCall,
+    CppDeclaration,
+    CppExprStatement,
+    CppFunction,
+    CppNode,
+    CppRenderer,
+    CppReturn,
+    CppSourceFile,
+)
 from .plugins import (
     ATTR_DISPATCH_TABLE,
     CLASS_DISPATCH_TABLE,
@@ -108,6 +121,21 @@ class CppListComparisonRewriter(ast.NodeTransformer):
 class CppTranspiler(CLikeTranspiler):
     NAME = "cpp"
 
+    def __getattribute__(self, name):
+        attr = super().__getattribute__(name)
+        if not callable(attr):
+            return attr
+        if not (name.startswith("visit_") or name.startswith("_visit_")):
+            return attr
+
+        def cpp_node_visitor(*args, **kwargs):
+            result = attr(*args, **kwargs)
+            if isinstance(result, str):
+                return CppNode(result)
+            return result
+
+        return cpp_node_visitor
+
     def __init__(self, extension: bool = False, no_prologue: bool = False):
         super().__init__()
         self._headers = []
@@ -130,6 +158,37 @@ class CppTranspiler(CLikeTranspiler):
     def _get_nolint_suffix(self, nolint="build/include_order"):
         return f"  // NOLINT({nolint})" if not self._no_prologue else ""
 
+    def visit(self, node) -> CppNode:
+        result = super().visit(node)
+        if isinstance(result, str):
+            return CppNode(result)
+        return result
+
+    def visit_Module(self, node) -> CppNode:
+        cpp_ast = self.visit_Module_ast(node)
+        return CppNode(CppRenderer().render(cpp_ast))
+
+    def visit_Module_ast(self, node) -> CppSourceFile:
+        docstring = getattr(node, "docstring_comment", None)
+        items = [self.comment(docstring.value)] if docstring is not None else []
+        filename = getattr(node, "__file__", None)
+        self._reset()
+        if filename is not None:
+            self._module = Path(filename).stem
+
+        body_items = {}
+        for b in node.body:
+            if not isinstance(b, ast.FunctionDef):
+                body_items[b] = self.visit(b)
+        # Second pass to handle functiondefs whose body may refer to other
+        # members of node.body.
+        for b in node.body:
+            if isinstance(b, ast.FunctionDef):
+                body_items[b] = self.visit(b)
+
+        items += [body_items[b] for b in node.body]
+        return CppSourceFile.from_items(items)
+
     def usings(self):
         usings = sorted(list(set(self._usings)))
         lint_exception = self._get_nolint_suffix()
@@ -144,7 +203,7 @@ class CppTranspiler(CLikeTranspiler):
             self._headers.append("#include <stdint.h>")
         return "\n".join([f"{line}{lint_exception}" for line in self._headers])
 
-    def visit_FunctionDef(self, node) -> str:
+    def visit_FunctionDef(self, node) -> CppNode:
         body = "\n".join([self.visit(n) for n in node.body])
         # If rewriter inserted a block, we need to terminate it with a semicolon
         if len(node.body):
@@ -157,7 +216,7 @@ class CppTranspiler(CLikeTranspiler):
             and is_void_function(node)
             and node.name.startswith("test")
         ):
-            return generate_catch_test_case(node, body)
+            return CppNode(generate_catch_test_case(node, body))
 
         is_python_main = getattr(node, "python_main", False)
         typenames, args = self.visit(node.args)
@@ -199,9 +258,9 @@ class CppTranspiler(CLikeTranspiler):
             return_type = "void"
 
         args = ", ".join(args_list)
-        funcdef = f"{template}{return_type} {node.name}({args}) {{"
+        funcdef = f"{template}{return_type} {node.name}({args})"
 
-        return funcdef + "\n" + body + "}\n"
+        return CppFunction(funcdef, [body])
 
     def visit_Global(self, node) -> str:
         return ""
@@ -336,7 +395,7 @@ class CppTranspiler(CLikeTranspiler):
             """
         )
 
-    def visit_Call(self, node) -> str:
+    def visit_Call(self, node) -> CppNode:
         fname = self.visit(node.func)
         vargs = []
 
@@ -347,13 +406,12 @@ class CppTranspiler(CLikeTranspiler):
 
         ret = self._dispatch(node, fname, vargs)
         if ret is not None:
-            return ret
+            return CppNode(ret)
 
         if any(i is None for i in vargs):
             raise AstNotImplementedError(f"Call {fname} ({vargs}) not supported", node)
 
-        args = ", ".join(vargs)
-        return f"{fname}({args})"
+        return CppCall(fname, vargs)
 
     def visit_For(self, node) -> str:
         target = self.visit(node.target)
@@ -419,11 +477,42 @@ class CppTranspiler(CLikeTranspiler):
         else:
             return super().visit_Constant(node)
 
-    def visit_Expr(self, node) -> str:
+    @staticmethod
+    def _is_none_constant(node):
+        return isinstance(node, ast.Constant) and node.value is None
+
+    @staticmethod
+    def _is_non_none_constant(node):
+        return isinstance(node, ast.Constant) and node.value is not None
+
+    def visit_Compare(self, node) -> CppNode:
+        if len(node.ops) == 1 and len(node.comparators) == 1:
+            left = node.left
+            right = node.comparators[0]
+            none_compared_to_value = (
+                self._is_none_constant(left) and self._is_non_none_constant(right)
+            ) or (self._is_non_none_constant(left) and self._is_none_constant(right))
+            if none_compared_to_value:
+                if isinstance(node.ops[0], (ast.NotEq, ast.IsNot)):
+                    return CppNode("true")
+                if isinstance(node.ops[0], (ast.Eq, ast.Is)):
+                    return CppNode("false")
+        return CppNode(super().visit_Compare(node))
+
+    def visit_Expr(self, node) -> CppNode:
         s = super().visit_Expr(node)
         if getattr(node, "unused", False):
             s = "(void) " + s
-        return s
+        if isinstance(node.value, ast.Constant) and node.value.value is Ellipsis:
+            return CppNode(s)
+        if not s:
+            return CppNode("")
+        return CppExprStatement(s)
+
+    def visit_Return(self, node) -> CppNode:
+        if node.value:
+            return CppReturn(self.visit(node.value))
+        return CppReturn()
 
     def _make_block(self, node):
         buf = []
@@ -593,22 +682,33 @@ class CppTranspiler(CLikeTranspiler):
             return f"assert({self.visit(node.test)});"
         return f"REQUIRE({self.visit(node.test)});"
 
-    def _visit_AssignOne(self, node, target) -> str:
+    def visit_Assign(self, node) -> CppNode:
+        return CppNode(
+            "\n".join([self._visit_AssignOne(node, target) for target in node.targets])
+        )
+
+    def visit_AugAssign(self, node) -> CppNode:
+        target = self.visit(node.target)
+        op = self.visit(node.op)
+        val = self.visit(node.value)
+        return CppAugAssignment(target, op, val)
+
+    def _visit_AssignOne(self, node, target) -> CppNode:
         if isinstance(target, ast.Tuple):
             elts = [self.visit(e) for e in target.elts]
             value = self.visit(node.value)
-            return "std::tie({}) = {};".format(", ".join(elts), value)
+            return CppNode("std::tie({}) = {};".format(", ".join(elts), value))
 
         if isinstance(node.scopes[-1], ast.If) and isinstance(target, ast.Name):
             outer_if = node.scopes[-1]
             if target.id in outer_if.common_vars:
                 value = self.visit(node.value)
-                return f"{target.id} = {value};"
+                return CppAssignment(target.id, value)
 
         if isinstance(target, ast.Subscript):
             target = self.visit(target)
             value = self.visit(node.value)
-            return f"{target} = {value};"
+            return CppAssignment(target, value)
 
         definition = node.scopes.parent_scopes.find(get_id(target))
         if definition is None:
@@ -616,7 +716,7 @@ class CppTranspiler(CLikeTranspiler):
         if isinstance(target, ast.Name) and defined_before(definition, node):
             target = self.visit(target)
             value = self.visit(node.value)
-            return f"{target} = {value};"
+            return CppAssignment(target, value)
 
         if isinstance(node.value, ast.List):
             element_type = self._get_element_type(node.value)
@@ -632,13 +732,13 @@ class CppTranspiler(CLikeTranspiler):
         lint_exception = self._get_nolint_suffix("runtime/string")
         if typename == "std::string" and is_global(node):
             self._usings.add("<string>")
-            return f"{typename} {target} = {value};{lint_exception}"
+            return CppDeclaration(typename, target, value, suffix=lint_exception)
 
-        return f"{typename} {target} = {value};"
+        return CppDeclaration(typename, target, value)
 
-    def visit_AnnAssign(self, node) -> str:
+    def visit_AnnAssign(self, node) -> CppNode:
         target, type_str, val = super().visit_AnnAssign(node)
-        return f"{type_str} {target} = {val};"
+        return CppDeclaration(type_str, target, val)
 
     def visit_Print(self, node) -> str:
         buf = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 dependencies = [
     "argparse_dataclass",
     "tree-sitter",
+    "tree-sitter-cpp",
     "tree-sitter-rust",
 ]
 dynamic = ["version"]

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("py2many/version.py") as f:
             delim = '"' if '"' in line else "'"
             version = line.split(delim)[1]
 
-install_requires = ["tree-sitter", "tree-sitter-rust"]
+install_requires = ["tree-sitter", "tree-sitter-cpp", "tree-sitter-rust"]
 setup_requires = []
 test_deps = ["pytest", "argparse_dataclass"]
 

--- a/tests/expected/coverage.cpp
+++ b/tests/expected/coverage.cpp
@@ -7,11 +7,9 @@
 #include <string>                  // NOLINT(build/include_order)
 #include <vector>                  // NOLINT(build/include_order)
 
-inline void inline_pass() {
-/* pass */}
+inline void inline_pass() { /* pass */ }
 
-inline void inline_ellipsis() {
-/* ... */}
+inline void inline_ellipsis() { /* ... */ }
 
 inline int indexing() {
   int sum = 0;
@@ -87,7 +85,7 @@ inline void show() {
     std::cout << std::string{"true"};
     std::cout << std::endl;
   }
-  if (1 != NULL) {
+  if (true) {
     std::cout << std::string{"World is sane"};
     std::cout << std::endl;
   }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import argparse
+import difflib
 import logging
 import os.path
 import platform
@@ -17,9 +18,7 @@ from py2many.cli import (
     _relative_to_cwd,
 )
 from py2many.cli import _run as run
-from py2many.cli import (
-    main,
-)
+from py2many.cli import main
 from py2many.process_helpers import find_executable
 
 try:
@@ -44,6 +43,36 @@ ENV = {
     "cpp": {"CLANG_FORMAT_STYLE": "Google"},
     "rust": {"RUSTFLAGS": "--deny warnings"},
 }
+
+
+def assert_expected_matches_generated(
+    expected: str,
+    generated: str,
+    *,
+    case: str,
+    lang: str,
+    expected_filename: Path,
+    generated_filename: Path,
+):
+    if expected == generated:
+        return
+
+    diff = "".join(
+        difflib.unified_diff(
+            expected.splitlines(keepends=True),
+            generated.splitlines(keepends=True),
+            fromfile=str(expected_filename),
+            tofile=str(generated_filename),
+        )
+    )
+    raise AssertionError(
+        f"Generated output mismatch for {case}-{lang}\n"
+        f"Expected: {expected_filename}\n"
+        f"Generated: {generated_filename}\n"
+        f"\n{diff}"
+    )
+
+
 COMPILERS = {
     "cpp": [CXX, "-std=c++17", "-I", str(ROOT_DIR)]
     + _conan_include_args()
@@ -272,7 +301,14 @@ class TestCodeGenerator:
                                 expected_case_contents
                             )
                             generated_cleaned = standardise_python(generated)
-                        assert expected_case_contents == generated_cleaned
+                        assert_expected_matches_generated(
+                            expected_case_contents,
+                            generated_cleaned,
+                            case=case,
+                            lang=lang,
+                            expected_filename=expected_filename,
+                            generated_filename=case_output,
+                        )
                         print("expected = generated")
 
             expect_failure = (

--- a/tests/test_cpp_ast.py
+++ b/tests/test_cpp_ast.py
@@ -1,0 +1,98 @@
+import ast
+
+from py2many.analysis import add_imports
+from py2many.context import add_list_calls, add_variable_context
+from py2many.pycpp.cpp_ast import (
+    CppAssignment,
+    CppAugAssignment,
+    CppCall,
+    CppDeclaration,
+    CppExprStatement,
+    CppFunction,
+    CppNode,
+    CppRawItem,
+    CppRenderer,
+    CppReturn,
+    CppSourceFile,
+)
+from py2many.pycpp.transpiler import CppTranspiler
+from py2many.scope import add_scope_context
+
+
+def _prepare_tree(source: str) -> ast.Module:
+    tree = ast.parse(source)
+    add_variable_context(tree, (tree,))
+    add_scope_context(tree)
+    add_list_calls(tree)
+    add_imports(tree)
+    return tree
+
+
+def test_cpp_source_file_renders_in_a_separate_pass():
+    cpp_ast = CppSourceFile.from_items(
+        [
+            CppRawItem.from_source("#include <cstdint>"),
+            CppRawItem.from_source("int answer() {\nreturn 42;\n}\n"),
+        ]
+    )
+
+    rendered = CppRenderer().render(cpp_ast)
+
+    assert rendered == "#include <cstdint>\nint answer() {\nreturn 42;\n}\n"
+
+
+def test_tree_sitter_node_keeps_cpp_parse_tree_when_dependency_is_available():
+    item = CppRawItem.from_source("int main() {\nreturn 0;\n}\n")
+
+    assert item.node.kind == "translation_unit"
+    assert item.render().startswith("int main()")
+
+
+def test_simple_cpp_ast_nodes_render_source():
+    assert CppCall("fib", ["n - 1"]).render() == "fib(n - 1)"
+    assert CppReturn("answer").render() == "return answer;"
+    assert CppAssignment("answer", "42").render() == "answer = 42;"
+    assert CppAugAssignment("answer", "+", "1").render() == "answer += 1;"
+    assert CppDeclaration("int", "answer", "42").render() == "int answer = 42;"
+    assert CppExprStatement("answer").render() == "answer;"
+    assert CppFunction("int answer()", [CppReturn("42")]).render() == (
+        "int answer() {\nreturn 42;\n}\n"
+    )
+
+
+def test_cpp_transpiler_simple_visitors_return_tree_sitter_nodes():
+    tree = _prepare_tree(
+        "def f(x: int) -> int:\n"
+        "    y: int = inc(x)\n"
+        "    y = inc(y)\n"
+        "    y += 1\n"
+        "    return y\n"
+    )
+    function = tree.body[0]
+    declaration = function.body[0]
+    assignment = function.body[1]
+    aug_assignment = function.body[2]
+    return_node = function.body[3]
+    transpiler = CppTranspiler(no_prologue=True)
+
+    rendered_call = transpiler.visit_Call(declaration.value)
+    rendered_return = transpiler.visit_Return(return_node)
+    rendered_declaration = transpiler.visit_AnnAssign(declaration)
+    rendered_assignment = transpiler.visit_Assign(assignment)
+    rendered_aug_assignment = transpiler.visit_AugAssign(aug_assignment)
+    rendered_function = transpiler.visit_FunctionDef(function)
+
+    assert isinstance(rendered_call, CppNode)
+    assert rendered_call.render() == "inc(x)"
+    assert rendered_return.render() == "return y;"
+    assert rendered_declaration.render() == "int y = inc(x);"
+    assert rendered_assignment.render() == "y = inc(y);"
+    assert rendered_aug_assignment.render() == "y += 1;"
+    assert rendered_function.render() == (
+        "inline int f(int x) {\n"
+        "int y = inc(x);\n"
+        "y = inc(y);\n"
+        "y += 1;\n"
+        "return y;\n"
+        "}\n"
+    )

--- a/tests/test_transpile_self.py
+++ b/tests/test_transpile_self.py
@@ -246,7 +246,7 @@ class SelfTranspileTests(unittest.TestCase):
         successful, format_errors, failures = _process_dir(
             settings, transpiler_module, OUT_DIR, False, _suppress_exceptions=False
         )
-        assert len(successful) == 5
+        assert len(successful) == 6
 
         successful, format_errors, failures = _process_dir(
             settings, PY2MANY_MODULE, OUT_DIR, False, _suppress_exceptions=False

--- a/tests/test_unsupported.py
+++ b/tests/test_unsupported.py
@@ -27,16 +27,9 @@ from test_cli import LANGS as _LANGS
 from test_cli import SHOW_ERRORS, TESTS_DIR, get_exe_filename, has_main_lines
 
 import py2many.cli
-from py2many.cli import (
-    _create_cmd,
-    _get_all_settings,
-    _relative_to_cwd,
-)
+from py2many.cli import _create_cmd, _get_all_settings, _relative_to_cwd
 from py2many.cli import _run as run
-from py2many.cli import (
-    _transpile,
-    _transpile_one,
-)
+from py2many.cli import _transpile, _transpile_one
 from py2many.exceptions import AstIncompatibleAssign
 from py2many.process_helpers import find_executable
 


### PR DESCRIPTION
Fixes: #770 

## Summary
- add a tree-sitter-backed C++ AST/render layer
- route simple C++ transpiler visitors through renderable C++ nodes
- add focused tests for C++ AST rendering and converted visitors

