### PR TITLE
Lean: end to end flow

### DIFF
--- a/LANGUAGES.md
+++ b/LANGUAGES.md
@@ -1,6 +1,6 @@
 | Language | Cases | Notable failures |
 | --- | --- | --- |
-| Python | 57 |  |
+| Python | 58 |  |
 | V | 48 | global, stdio |
 | Lean | 47 |  |
 | Go | 40 | stdio |

--- a/LANGUAGES.md
+++ b/LANGUAGES.md
@@ -2,7 +2,7 @@
 | --- | --- | --- |
 | Python | 57 |  |
 | V | 48 | global, stdio |
-| Lean | 46 |  |
+| Lean | 47 |  |
 | Go | 40 | stdio |
 | Rust | 38 | math_func, stdio |
 | Julia | 37 | fstring, stdio |

--- a/py2many/analysis.py
+++ b/py2many/analysis.py
@@ -17,6 +17,7 @@ IGNORED_MODULE_SET = {
     "adt",
     "py2many.result",
     "py2many.smt",
+    "py2many.spec",
 }
 
 

--- a/py2many/analysis.py
+++ b/py2many/analysis.py
@@ -18,6 +18,7 @@ IGNORED_MODULE_SET = {
     "py2many.result",
     "py2many.smt",
     "py2many.spec",
+    "py2many.theorem",
 }
 
 

--- a/py2many/cli.py
+++ b/py2many/cli.py
@@ -20,6 +20,7 @@ from .process_helpers import find_executable
 from .raises_transformer import detect_raises
 from .registry import ALL_SETTINGS, FAKE_ARGS, _get_all_settings
 from .rewriters import (
+    CheckerBlockRemover,
     ComplexDestructuringRewriter,
     DocStringToCommentRewriter,
     DropClassGetItemRewriter,
@@ -87,6 +88,7 @@ def _transpile(
     topo_filenames = [t.__file__ for t in trees]
     language = transpiler.NAME
     generic_rewriters = [
+        CheckerBlockRemover(language),
         ComplexDestructuringRewriter(language),
         PythonMainRewriter(settings.transpiler._main_signature_arg_names),
         FStringJoinRewriter(language),

--- a/py2many/rewriters.py
+++ b/py2many/rewriters.py
@@ -549,3 +549,45 @@ class LoopElseRewriter(ast.NodeTransformer):
                 body.append(n)
 
         node.body = body
+
+
+class CheckerBlockRemover(ast.NodeTransformer):
+    """Strips ``if CHECKER.pre:`` / ``if CHECKER.post:`` / ``if CHECKER.invariant:``
+    blocks from the AST for backends that do not process them (all except Lean).
+
+    Verifies that ``CHECKER`` was imported from ``py2many.spec`` before stripping.
+    """
+
+    def __init__(self, language: str):
+        super().__init__()
+        self._language = language
+        self._checker_import_verified = False
+
+    def _is_checker_import_from_spec(self, tree: ast.Module) -> bool:
+        """Scan module-level imports for ``from py2many.spec import CHECKER``."""
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                if node.module == "py2many.spec":
+                    for alias in node.names:
+                        if alias.name == "CHECKER":
+                            return True
+        return False
+
+    def visit_Module(self, node: ast.Module) -> ast.Module:
+        if self._language == "lean":
+            return node  # Lean handles CHECKER blocks itself
+        self._checker_import_verified = self._is_checker_import_from_spec(node)
+        self.generic_visit(node)
+        return node
+
+    def visit_If(self, node: ast.If) -> Any:
+        if not self._checker_import_verified:
+            return node
+        if isinstance(node.test, ast.Attribute):
+            if (
+                isinstance(node.test.value, ast.Name)
+                and node.test.value.id == "CHECKER"
+            ):
+                # Strip the entire if block
+                return None
+        return node

--- a/py2many/spec.py
+++ b/py2many/spec.py
@@ -1,0 +1,76 @@
+"""Backend-agnostic specification markers for py2many.
+
+Usage::
+
+    from py2many.spec import CHECKER
+
+    @dataclass
+    class BankAccount:
+        balance: int
+
+        if CHECKER.invariant:
+            balance >= 0
+
+        def deposit(self, amount: int) -> "BankAccount":
+            if CHECKER.pre:
+                amount > 0
+            if CHECKER.post:
+                result.balance == self.balance + amount
+            return BankAccount(self.balance + amount)
+
+
+``CHECKER.pre`` / ``CHECKER.post`` / ``CHECKER.invariant`` evaluate to
+``False`` at runtime, so the ``if`` blocks are compiled out by any Python
+interpreter.  py2many backends (Lean, SMT, …) recognise the dotted access
+and treat the block bodies as proof obligations.
+
+Legacy flat names (``pre``, ``post``, ``invariant``) are also exported for
+backward compatibility with the older ``py2many.smt`` module.
+"""
+
+
+def check(claim: bool):
+    """Assert a linear-arithmetic claim about specific values.
+
+    Python checks it at runtime; the Lean backend discharges it with ``omega``
+    at compile time — the runnable analogue of an SMT ``check-sat`` + model.
+    """
+    assert claim
+
+
+def prove(fn):
+    """Assert that a boolean function holds for every boolean input.
+
+    Python exhaustively evaluates the finite ``bool`` domain so the case is
+    ordinary runnable code.  The Lean backend compiles it to ``by decide``.
+    """
+    import inspect
+    from itertools import product
+
+    n = len(inspect.signature(fn).parameters)
+    assert all(fn(*combo) for combo in product((True, False), repeat=n))
+
+
+# ── CHECKER namespace (preferred API) ─────────────────────────
+
+
+class _Checker:
+    """Sentinel object whose attributes are always ``False``.
+
+    ``if CHECKER.pre:`` blocks are eliminated at runtime by the Python
+    bytecode compiler (the condition is a compile-time constant ``False``)
+    and recognised by py2many's AST pass as specification markers.
+    """
+
+    pre = False
+    post = False
+    invariant = False
+
+
+CHECKER = _Checker()
+
+# ── Legacy flat exports (kept for backward compat) ────────────
+
+pre = CHECKER.pre
+post = CHECKER.post
+invariant = CHECKER.invariant

--- a/py2many/theorem.py
+++ b/py2many/theorem.py
@@ -1,0 +1,29 @@
+"""Transpiler-only decorator markers for py2many.
+
+These decorators are recognised by py2many's AST pass and are no-ops at
+Python runtime.  Import them so your source file stays executable::
+
+    from py2many.theorem import theorem, lemma, by
+"""
+
+
+def theorem(fn):
+    """Marker for py2many: emit ``theorem`` instead of ``def``."""
+    return fn
+
+
+def lemma(fn):
+    """Marker for py2many: emit ``theorem`` (alias for ``lemma``)."""
+    return fn
+
+
+def by(tactic: str):
+    """Marker for py2many: use *tactic* as the proof block.
+
+    At runtime this is a no-op decorator that returns the function unchanged.
+    """
+
+    def decorator(fn):
+        return fn
+
+    return decorator

--- a/pylean/plugins.py
+++ b/pylean/plugins.py
@@ -278,7 +278,10 @@ DISPATCH_MAP = {
 
 MODULE_DISPATCH_TABLE: Dict[str, str] = {}
 
-DECORATOR_DISPATCH_TABLE: Dict[str, Callable] = {}
+DECORATOR_DISPATCH_TABLE: Dict[str, Callable] = {
+    "theorem": lambda self, node: node,
+    "by": lambda self, node: node,
+}
 
 ATTR_DISPATCH_TABLE: Dict[type, Callable] = {}
 

--- a/pylean/plugins.py
+++ b/pylean/plugins.py
@@ -280,7 +280,13 @@ MODULE_DISPATCH_TABLE: Dict[str, str] = {}
 
 DECORATOR_DISPATCH_TABLE: Dict[str, Callable] = {
     "theorem": lambda self, node: node,
+    "lemma": lambda self, node: node,
     "by": lambda self, node: node,
+    "invariant": lambda self, node: node,
+    "pre": lambda self, node: node,
+    "precondition": lambda self, node: node,
+    "post": lambda self, node: node,
+    "postcondition": lambda self, node: node,
 }
 
 ATTR_DISPATCH_TABLE: Dict[type, Callable] = {}

--- a/pylean/transpiler.py
+++ b/pylean/transpiler.py
@@ -144,8 +144,47 @@ class LeanTranspiler(CLikeTranspiler):
         return f"import {name}"
 
     def _import_from(self, module_name: str, names: List[str], level: int = 0) -> str:
+        # Drop transpiler-marker imports like ``py2many.theorem`` — these are
+        # not real Python modules, they are annotations recognised by py2many
+        # and have no corresponding Lean library.
+        if module_name in ("py2many.theorem",):
+            return ""
         lookup = MODULE_DISPATCH_TABLE.get(module_name, module_name)
         return f"import {lookup}"
+
+    def _get_theorem_name(self, node) -> str:
+        """Return the decorator id for a function node, checking for @theorem."""
+        for d in node.decorator_list:
+            name = get_id(d)
+            if name == "theorem":
+                return "theorem"
+        return None
+
+    def _extract_by_tactic(self, node) -> str:
+        """If ``@by('tactic')`` is present, return the tactic string."""
+        for d in node.decorator_list:
+            if isinstance(d, ast.Call):
+                fn = get_id(d.func)
+                if fn == "by" and d.args:
+                    val = d.args[0]
+                    if isinstance(val, ast.Constant) and isinstance(val.value, str):
+                        return val.value
+        return None
+
+    def _theorem_proposition(self, node, fn_body) -> str:
+        """Extract the proposition from a @theorem function body.
+
+        The body should contain a single ``return <expr>`` statement which
+        expresses the property to prove.  Returns the Lean expression.
+        """
+        # If body is a single return, use the return expression directly
+        if len(fn_body) == 1 and isinstance(fn_body[0], ast.Return):
+            expr = fn_body[0].value
+            if expr is not None:
+                return f"({self.visit(expr)}) = true"
+        # Otherwise, build the proposition from the full body
+        body_lean = "\n".join(self.visit(s) for s in fn_body)
+        return body_lean
 
     def _mutable_param_bindings(self, node) -> List[str]:
         """Emit ``let mut arg := arg`` for function params that are reassigned.
@@ -174,6 +213,10 @@ class LeanTranspiler(CLikeTranspiler):
         self._dependent_vars = set()
         saved_int_params = self._int_params
         self._int_params = set()
+
+        # Check for @theorem and @by decorators
+        is_theorem = self._get_theorem_name(node) == "theorem"
+        by_tactic = self._extract_by_tactic(node)
 
         # Python's `if __name__ == "__main__"` block is rewritten into a main()
         # function; Lean's runtime invokes `main : IO Unit` automatically, so no
@@ -265,6 +308,23 @@ class LeanTranspiler(CLikeTranspiler):
         # ``Id.run do return expr``.  This is more idiomatic and, unlike a do
         # block, the formatter can freely wrap a long expression without
         # breaking Lean's indentation-sensitive ``do`` parsing.
+        # Emit theorem or def
+        if is_theorem:
+            # Extract the proposition from the return statement in the body
+            prop = self._theorem_proposition(node, fn_body)
+            tactic_block = by_tactic if by_tactic else body
+            theorem_str = f"{partial}theorem {func_name}{args_str} : {prop} := by"
+            if by_tactic:
+                # Single-line tactic (e.g. native_decide, omega)
+                out = f"{theorem_str}\n{self.indent(tactic_block, level=node.level + 1)}\n"
+            else:
+                # Multi-line proof from the transpiled body
+                out = f"{theorem_str}\n{tactic_block}\n"
+            self._bound_vars = saved_bound
+            self._dependent_vars = saved_dep
+            self._int_params = saved_int_params
+            return self.indent(out, level=node.level)
+
         if (
             not _is_io_function(node)
             and not mut_bindings
@@ -699,6 +759,15 @@ class LeanTranspiler(CLikeTranspiler):
             list_name = self.visit(node.func.value)
             val = self.visit(node.args[0])
             return f"{list_name} := {list_name} ++ [{val}]"
+        # Handle list.extend: lst.extend(xs) -> lst := lst ++ xs
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "extend"
+            and node.args
+        ):
+            list_name = self.visit(node.func.value)
+            val = self.visit(node.args[0])
+            return f"{list_name} := {list_name} ++ {val}"
 
         # Handle list.keys() and list.values()
         if isinstance(node.func, ast.Attribute) and node.func.attr == "keys":
@@ -964,11 +1033,37 @@ class LeanTranspiler(CLikeTranspiler):
 
     def visit_Subscript(self, node) -> str:
         value = self.visit(node.value)
+        # Handle slices: arr[:n] or arr[n:]
+        if isinstance(node.slice, ast.Slice):
+            return self.visit_Slice(node.slice, value)
         index = self._index_str(node.slice)
         return f"{value}[{index}]!"
 
     def visit_Index(self, node) -> str:
         return self.visit(node.value)
+
+    def visit_Slice(self, node, list_name=None) -> str:
+        """Translate Python slices to Lean List.take / List.drop.
+
+        ``arr[:n]``  → ``List.take n arr``
+        ``arr[n:]``  → ``List.drop n arr``
+        ``arr[:]``   → ``arr``
+        """
+        if list_name is None:
+            return self.comment("Slice used as annotation -- unsupported")
+        lower = self.visit(node.lower) if node.lower else None
+        upper = self.visit(node.upper) if node.upper else None
+        if lower is not None and upper is not None:
+            # arr[lower:upper] → List.drop lower arr |>.take (upper - lower)
+            return f"(List.drop {lower} {list_name} |>.take ({upper} - {lower}))"
+        if lower is not None:
+            # arr[lower:] → List.drop lower arr
+            return f"(List.drop {lower} {list_name})"
+        if upper is not None:
+            # arr[:upper] → List.take upper arr
+            return f"(List.take {upper} {list_name})"
+        # arr[:]  identity
+        return list_name
 
     def visit_Delete(self, node) -> str:
         parts = []

--- a/pylean/transpiler.py
+++ b/pylean/transpiler.py
@@ -147,7 +147,7 @@ class LeanTranspiler(CLikeTranspiler):
         # Drop transpiler-marker imports like ``py2many.theorem`` — these are
         # not real Python modules, they are annotations recognised by py2many
         # and have no corresponding Lean library.
-        if module_name in ("py2many.theorem", "py2many.smt"):
+        if module_name in ("py2many.theorem", "py2many.smt", "py2many.spec"):
             return ""
         lookup = MODULE_DISPATCH_TABLE.get(module_name, module_name)
         return f"import {lookup}"
@@ -320,7 +320,7 @@ class LeanTranspiler(CLikeTranspiler):
         # Precondition (#805): a leading ``if smt_pre:`` becomes a proof
         # parameter and is dropped from the emitted body.  Record the method
         # name so call sites can supply the proof argument.
-        precond, fn_body = self._extract_precondition(node)
+        precond, postcond, fn_body = self._extract_precondition(node)
         if precond:
             args_str += f" (pre : {precond})"
             self._precondition_methods.add(node.name)
@@ -443,18 +443,24 @@ class LeanTranspiler(CLikeTranspiler):
         ast.NotEq: "≠",
     }
 
-    def _visit_proposition(self, node) -> str:
+    def _visit_proposition(self, node, class_name: str = None) -> str:
         """Render a Python boolean expression as a Lean ``Prop``.
 
-        Used for dependent-type predicates (#804) and structure invariants
-        (#805).  Differs from the ``Bool`` rendering used by ``if`` in two
+        When *class_name* is given, dotted attribute references like
+        ``BankAccount.balance`` are shortened to just ``balance`` so they
+        work inside structure invariant fields where ``BankAccount`` is
+        being defined.
+
+        Differs from the ``Bool`` rendering used by ``if`` in two
         ways: ``and``/``or`` become ``∧``/``∨`` and Python's chained
         comparisons (``0 < x < 10``) expand to a conjunction
         (``0 < x ∧ x < 10``) since Lean has no chained relations.
         """
         if isinstance(node, ast.BoolOp):
             sym = "∧" if isinstance(node.op, ast.And) else "∨"
-            return f" {sym} ".join(self._visit_proposition(v) for v in node.values)
+            return f" {sym} ".join(
+                self._visit_proposition(v, class_name) for v in node.values
+            )
         if isinstance(node, ast.Compare):
             clauses = []
             left = node.left
@@ -462,11 +468,20 @@ class LeanTranspiler(CLikeTranspiler):
                 sym = self._PROP_CMP_OPS.get(type(op))
                 if sym is None:
                     return self.visit(node)
-                clauses.append(f"{self.visit(left)} {sym} {self.visit(right)}")
+                clauses.append(
+                    f"{self._visit_proposition(left, class_name)} {sym} "
+                    f"{self._visit_proposition(right, class_name)}"
+                )
                 left = right
             return " ∧ ".join(clauses)
         if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
-            return f"¬({self._visit_proposition(node.operand)})"
+            return f"¬({self._visit_proposition(node.operand, class_name)})"
+        # Strip class prefix from dotted names: ``BankAccount.balance`` → ``balance``
+        if class_name and isinstance(node, ast.Attribute):
+            val_id = get_id(node.value)
+            names = class_name if isinstance(class_name, set) else {class_name}
+            if val_id in names:
+                return node.attr
         return self.visit(node)
 
     def _dependent_parts(self, value):
@@ -511,21 +526,55 @@ class LeanTranspiler(CLikeTranspiler):
     def _extract_invariants(self, node) -> List[tuple]:
         """Collect ``(field_name, prop)`` from an ``if invariant:`` class block.
 
-        Realises #805's class invariants as extra structure fields of
-        proposition type, e.g. ``balance >= 0`` becomes
-        ``inv_balance : balance ≥ 0``.  The field name is derived from the
-        first variable mentioned, with a numeric suffix to break ties.
+        Two styles are recognised inside the block:
+
+        1. Bare expression: ``balance >= 0``
+        2. Class method: ``def invariant(cls): return cls.balance >= 0``
+
+        Both become a structure invariant field, e.g.
+        ``inv_balance : balance ≥ 0``.
         """
         invariants: List[tuple] = []
         used: set = set()
         for stmt in node.body:
-            if not (isinstance(stmt, ast.If) and get_id(stmt.test) == "invariant"):
+            if not (
+                isinstance(stmt, ast.If) and self._checker_attr(stmt.test, "invariant")
+            ):
                 continue
             for inner in stmt.body:
+                # Style 2: ``def invariant(cls): return expr``
+                if isinstance(inner, ast.FunctionDef):
+                    ret = inner.body[-1] if inner.body else None
+                    if isinstance(ret, ast.Return) and ret.value is not None:
+                        # The param (``cls`` / ``self``) is the class reference.
+                        # We pass both the class name and the param name so
+                        # _visit_proposition strips either prefix.
+                        cls_param = inner.args.args[0].arg if inner.args.args else None
+                        class_names = {node.name}
+                        if cls_param:
+                            class_names.add(cls_param)
+                        prop = self._visit_proposition(ret.value, class_names)
+                        base = "inv"
+                        for sub in ast.walk(ret.value):
+                            if isinstance(sub, ast.Attribute):
+                                base = f"inv_{sub.attr}"
+                                break
+                        name = base
+                        suffix = 2
+                        while name in used:
+                            name = f"{base}_{suffix}"
+                            suffix += 1
+                        used.add(name)
+                        invariants.append((name, prop))
+                    continue
+                # Style 1: bare expression
                 if not isinstance(inner, ast.Expr):
                     continue
                 base = "inv"
                 for sub in ast.walk(inner.value):
+                    if isinstance(sub, ast.Attribute):
+                        base = f"inv_{sub.attr}"
+                        break
                     if isinstance(sub, ast.Name):
                         base = f"inv_{sub.id}"
                         break
@@ -535,19 +584,37 @@ class LeanTranspiler(CLikeTranspiler):
                     name = f"{base}_{suffix}"
                     suffix += 1
                 used.add(name)
-                invariants.append((name, self._visit_proposition(inner.value)))
+                invariants.append(
+                    (name, self._visit_proposition(inner.value, node.name))
+                )
         return invariants
 
-    def _extract_precondition(self, node):
-        """Split a leading ``if smt_pre:`` block off a function body (#805).
+    @staticmethod
+    def _checker_attr(node, attr: str) -> bool:
+        """Return True when *node* is ``CHECKER.<attr>`` (dotted access).
 
-        Returns ``(precondition_prop_or_None, body_without_smt_pre)``.  The
-        precondition becomes a proof parameter on the emitted ``def``.
+        Also matches the plain-name form ``<attr>`` for backward compatibility
+        with the older ``py2many.smt`` flat export.
+        """
+        if isinstance(node, ast.Attribute):
+            return get_id(node.value) == "CHECKER" and node.attr == attr
+        return get_id(node) == attr
+
+    def _extract_precondition(self, node):
+        """Split ``if CHECKER.pre:`` / ``if CHECKER.post:`` blocks off a function body.
+
+        Returns ``(precondition_prop_or_None, postcondition_prop_or_None, body_without)``.
+        The precondition becomes a proof parameter; the postcondition is a
+        constraint on the return value.
         """
         pre = None
+        post = None
         body = []
         for stmt in node.body:
-            if isinstance(stmt, ast.If) and get_id(stmt.test) == "smt_pre":
+            if isinstance(stmt, ast.If) and (
+                self._checker_attr(stmt.test, "pre")
+                or self._checker_attr(stmt.test, "smt_pre")
+            ):
                 preds = [
                     self._visit_proposition(s.value)
                     for s in stmt.body
@@ -556,8 +623,17 @@ class LeanTranspiler(CLikeTranspiler):
                 if preds:
                     pre = " ∧ ".join(preds)
                 continue
+            if isinstance(stmt, ast.If) and self._checker_attr(stmt.test, "post"):
+                preds = [
+                    self._visit_proposition(s.value)
+                    for s in stmt.body
+                    if isinstance(s, ast.Expr)
+                ]
+                if preds:
+                    post = " ∧ ".join(preds)
+                continue
             body.append(stmt)
-        return pre, body
+        return pre, post, body
 
     def _visit_AssignOne(self, node, target) -> str:
         # Dependent type aliases (#804): ``Uid = Annotated[int, lambda u: ...]``

--- a/pylean/transpiler.py
+++ b/pylean/transpiler.py
@@ -147,7 +147,7 @@ class LeanTranspiler(CLikeTranspiler):
         # Drop transpiler-marker imports like ``py2many.theorem`` — these are
         # not real Python modules, they are annotations recognised by py2many
         # and have no corresponding Lean library.
-        if module_name in ("py2many.theorem",):
+        if module_name in ("py2many.theorem", "py2many.smt"):
             return ""
         lookup = MODULE_DISPATCH_TABLE.get(module_name, module_name)
         return f"import {lookup}"
@@ -160,19 +160,31 @@ class LeanTranspiler(CLikeTranspiler):
                 return "theorem"
         return None
 
-    def _extract_by_tactic(self, node) -> str:
-        """If ``@by('tactic')`` is present, return the tactic string."""
+    def _get_decorator_name(self, node, names: set) -> str:
+        """Return the first matching decorator name from *names*, or None."""
+        for d in node.decorator_list:
+            name = get_id(d)
+            if name in names:
+                return name
+        return None
+
+    def _extract_decorator_string(self, node, decorator_name: str) -> str:
+        """Extract a string argument from a decorator like ``@invariant('prop')``."""
         for d in node.decorator_list:
             if isinstance(d, ast.Call):
                 fn = get_id(d.func)
-                if fn == "by" and d.args:
+                if fn == decorator_name and d.args:
                     val = d.args[0]
                     if isinstance(val, ast.Constant) and isinstance(val.value, str):
                         return val.value
         return None
 
+    def _extract_by_tactic(self, node) -> str:
+        """If ``@by('tactic')`` is present, return the tactic string."""
+        return self._extract_decorator_string(node, "by")
+
     def _theorem_proposition(self, node, fn_body) -> str:
-        """Extract the proposition from a @theorem function body.
+        """Extract the proposition from a @theorem or @lemma function body.
 
         The body should contain a single ``return <expr>`` statement which
         expresses the property to prove.  Returns the Lean expression.
@@ -185,6 +197,42 @@ class LeanTranspiler(CLikeTranspiler):
         # Otherwise, build the proposition from the full body
         body_lean = "\n".join(self.visit(s) for s in fn_body)
         return body_lean
+
+    def _get_invariant_decorator(self, node) -> List[tuple]:
+        """Collect invariants from @invariant decorators on a class.
+
+        Returns ``[(field_name, prop_str), ...]`` matching the format
+        of ``_extract_invariants`` so the same emission path is reused.
+        """
+        props = []
+        used: set = set()
+        for d in node.decorator_list:
+            if isinstance(d, ast.Call):
+                fn = get_id(d.func)
+                if fn == "invariant" and d.args:
+                    val = d.args[0]
+                    if isinstance(val, ast.Constant) and isinstance(val.value, str):
+                        prop = val.value
+                        # Derive field name from the first identifier in the prop
+                        base = "inv"
+                        for tok in prop.split():
+                            if tok.isidentifier() and tok not in (
+                                "not",
+                                "and",
+                                "or",
+                                "=",
+                                "!=",
+                            ):
+                                base = f"inv_{tok}"
+                                break
+                        name = base
+                        suffix = 2
+                        while name in used:
+                            name = f"{base}_{suffix}"
+                            suffix += 1
+                        used.add(name)
+                        props.append((name, prop))
+        return props
 
     def _mutable_param_bindings(self, node) -> List[str]:
         """Emit ``let mut arg := arg`` for function params that are reassigned.
@@ -215,8 +263,16 @@ class LeanTranspiler(CLikeTranspiler):
         self._int_params = set()
 
         # Check for @theorem and @by decorators
-        is_theorem = self._get_theorem_name(node) == "theorem"
+        # Check for @theorem / @lemma and decorators
+        decor_keyword = self._get_decorator_name(node, {"theorem", "lemma"})
         by_tactic = self._extract_by_tactic(node)
+        # Check for @pre / @precondition and @post / @postcondition
+        pre_cond = self._extract_decorator_string(
+            node, "pre"
+        ) or self._extract_decorator_string(node, "precondition")
+        post_cond = self._extract_decorator_string(
+            node, "post"
+        ) or self._extract_decorator_string(node, "postcondition")
 
         # Python's `if __name__ == "__main__"` block is rewritten into a main()
         # function; Lean's runtime invokes `main : IO Unit` automatically, so no
@@ -308,22 +364,34 @@ class LeanTranspiler(CLikeTranspiler):
         # ``Id.run do return expr``.  This is more idiomatic and, unlike a do
         # block, the formatter can freely wrap a long expression without
         # breaking Lean's indentation-sensitive ``do`` parsing.
-        # Emit theorem or def
-        if is_theorem:
-            # Extract the proposition from the return statement in the body
+        # Emit theorem, lemma, or def
+        if decor_keyword:
+            # Both ``@lemma`` and ``@theorem`` emit ``theorem``; the keyword
+            # ``lemma`` was not yet available in Lean 4 v4.32.2.
             prop = self._theorem_proposition(node, fn_body)
             tactic_block = by_tactic if by_tactic else body
-            theorem_str = f"{partial}theorem {func_name}{args_str} : {prop} := by"
+            thm_str = f"{partial}theorem {func_name}{args_str} : {prop} := by"
             if by_tactic:
                 # Single-line tactic (e.g. native_decide, omega)
-                out = f"{theorem_str}\n{self.indent(tactic_block, level=node.level + 1)}\n"
+                out = f"{thm_str}\n{self.indent(tactic_block, level=node.level + 1)}\n"
             else:
                 # Multi-line proof from the transpiled body
-                out = f"{theorem_str}\n{tactic_block}\n"
+                out = f"{thm_str}\n{tactic_block}\n"
             self._bound_vars = saved_bound
             self._dependent_vars = saved_dep
             self._int_params = saved_int_params
             return self.indent(out, level=node.level)
+
+        # @pre / @precondition adds a proof parameter
+        if pre_cond:
+            args_str += f" (hpre : {pre_cond})"
+            self._precondition_methods.add(node.name)
+        # @post / @postcondition adds a return-type constraint
+        if post_cond and node.returns:
+            ret_type = self._collapse_union(
+                self._typename_from_annotation(node, attr="returns")
+            )
+            return_type = f"{{ r : {ret_type} // {post_cond} }}"
 
         if (
             not _is_io_function(node)
@@ -788,6 +856,12 @@ class LeanTranspiler(CLikeTranspiler):
             and node.func.attr in self._precondition_methods
         ):
             vargs.append("(by omega)")
+        # Same for standalone functions with @pre / @precondition
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id in self._precondition_methods
+        ):
+            vargs.append("(by omega)")
 
         ret = self._dispatch(node, fname, vargs)
         if ret is not None:
@@ -880,7 +954,15 @@ class LeanTranspiler(CLikeTranspiler):
             fields.append(f"  {declaration} : {typename}")
 
         # Class invariants (#805) become extra proposition-typed fields.
+        # Merge invariants from ``if invariant:`` blocks and @invariant decorators.
         invariants = node.invariants = self._extract_invariants(node)
+        decor_invariants = self._get_invariant_decorator(node)
+        # Append decorator invariants, dedup by prop string
+        seen_props = {p for _, p in invariants}
+        for name, prop in decor_invariants:
+            if prop not in seen_props:
+                invariants.append((name, prop))
+                seen_props.add(prop)
         for inv_name, prop in invariants:
             fields.append(f"  {inv_name} : {prop}")
 
@@ -904,7 +986,8 @@ class LeanTranspiler(CLikeTranspiler):
                 if b.name == "__init__":
                     continue
                 b.self_type = node.name
-                method_defs.append(self.visit(b))
+                # Strip indentation — methods are top-level definitions in Lean
+                method_defs.append(self.visit(b).lstrip())
         self._self_invariants = saved_invariants
 
         if method_defs:

--- a/tests/cases/verified_sort.py
+++ b/tests/cases/verified_sort.py
@@ -1,0 +1,107 @@
+from dataclasses import dataclass
+from typing import List
+
+from py2many.spec import CHECKER
+from py2many.theorem import by, lemma, theorem
+
+# ── Class with invariant (CHECKER.invariant) ───────────────────
+
+
+@dataclass
+class BankAccount:
+    balance: int
+
+    if CHECKER.invariant:
+
+        def invariant(cls):
+            return cls.balance >= 0
+
+    def deposit(self, amount: int) -> "BankAccount":
+        if CHECKER.pre:
+            amount > 0
+        if CHECKER.post:
+            result.balance == self.balance + amount  # noqa: F821 — return value in postcondition
+        return BankAccount(self.balance + amount)
+
+
+# ── Function with precondition (CHECKER.pre) ───────────────────
+
+
+def safe_sqrt(n: int) -> int:
+    """Returns floor(sqrt(n)).  Requires n >= 0."""
+    if CHECKER.pre:
+        n >= 0
+    i: int = 0
+    while i * i <= n:
+        i += 1
+    return i - 1
+
+
+# ── @lemma (decorator style still works) ───────────────────────
+
+
+@lemma
+@by("native_decide")
+def sqrt_of_9() -> bool:
+    return safe_sqrt(9) == 3
+
+
+# ── Merge sort unchanged ──────────────────────────────────────
+
+
+def merge(left: List[int], right: List[int]) -> List[int]:
+    result: List[int] = []
+    i: int = 0
+    j: int = 0
+    while i < len(left) and j < len(right):
+        if left[i] <= right[j]:
+            result.append(left[i])
+            i += 1
+        else:
+            result.append(right[j])
+            j += 1
+    while i < len(left):
+        result.append(left[i])
+        i += 1
+    while j < len(right):
+        result.append(right[j])
+        j += 1
+    return result
+
+
+def take(xs: List[int], n: int) -> List[int]:
+    out: List[int] = []
+    i: int = 0
+    while i < n:
+        out.append(xs[i])
+        i += 1
+    return out
+
+
+def drop(xs: List[int], n: int) -> List[int]:
+    out: List[int] = []
+    i: int = n
+    while i < len(xs):
+        out.append(xs[i])
+        i += 1
+    return out
+
+
+def sort_u64(arr: List[int]) -> List[int]:
+    if len(arr) <= 1:
+        return arr
+    mid: int = len(arr) // 2
+    left: List[int] = sort_u64(take(arr, mid))
+    right: List[int] = sort_u64(drop(arr, mid))
+    return merge(left, right)
+
+
+@by("native_decide")
+@theorem
+def concrete_example() -> bool:
+    return sort_u64([3, 1, 4, 1, 5, 9, 2, 6]) == [1, 1, 2, 3, 4, 5, 6, 9]
+
+
+if __name__ == "__main__":
+    acct = BankAccount(10)
+    print("OK")

--- a/tests/expected/verified_sort.lean
+++ b/tests/expected/verified_sort.lean
@@ -1,0 +1,75 @@
+set_option linter.unusedVariables false
+
+structure BankAccount where
+  balance : Nat
+  inv_balance : balance ≥ 0
+
+def BankAccount.deposit (self : BankAccount) (amount : Nat) (pre : amount > 0) : BankAccount :=
+  { balance := (self.balance + amount), inv_balance := by have h0 := self.inv_balance; omega : BankAccount }
+
+def safe_sqrt (n : Nat) (pre : n ≥ 0) : Nat :=
+  Id.run
+    (do
+      let mut i : Nat := 0
+      while (i * i) ≤ n do
+        i := i + 1
+      return (i - 1))
+
+theorem sqrt_of_9 : ((safe_sqrt 9 (by omega)) == 3) = true := by native_decide
+
+def merge (left : List Nat) (right : List Nat) : List Nat :=
+  Id.run
+    (do
+      let mut result : List Nat := []
+      let mut i : Nat := 0
+      let mut j : Nat := 0
+      while (i < (left).length && j < (right).length) do
+        if left[i]! ≤ right[j]! then
+          result := result ++ [left[i]!]
+          i := i + 1
+        else
+          result := result ++ [right[j]!]
+          j := j + 1
+      while i < (left).length do
+        result := result ++ [left[i]!]
+        i := i + 1
+      while j < (right).length do
+        result := result ++ [right[j]!]
+        j := j + 1
+      return result)
+
+def take (xs : List Nat) (n : Nat) : List Nat :=
+  Id.run
+    (do
+      let mut out : List Nat := []
+      let mut i : Nat := 0
+      while i < n do
+        out := out ++ [xs[i]!]
+        i := i + 1
+      return out)
+
+def drop (xs : List Nat) (n : Nat) : List Nat :=
+  Id.run
+    (do
+      let mut out : List Nat := []
+      let mut i : Nat := n
+      while i < (xs).length do
+        out := out ++ [xs[i]!]
+        i := i + 1
+      return out)
+
+partial def sort_u64 (arr : List Nat) : List Nat :=
+  Id.run
+    (do
+      if (arr).length ≤ 1 then
+        return arr
+      let mid : Nat := ((arr).length / 2)
+      let left : List Nat := (sort_u64 (take arr mid))
+      let right : List Nat := (sort_u64 (drop arr mid))
+      return (merge left right))
+
+theorem concrete_example : ((sort_u64 [3, 1, 4, 1, 5, 9, 2, 6]) == [1, 1, 2, 3, 4, 5, 6, 9]) = true := by native_decide
+
+def main : IO Unit := do
+  let acct := { balance := 10, inv_balance := by omega : BankAccount }
+  IO.println "OK"

--- a/tests/expected/verified_sort.py
+++ b/tests/expected/verified_sort.py
@@ -1,0 +1,87 @@
+from typing import Callable, Dict, List, Set, Optional
+from ctypes import c_int8 as i8, c_int16 as i16, c_int32 as i32, c_int64 as i64
+from ctypes import c_uint8 as u8, c_uint16 as u16, c_uint32 as u32, c_uint64 as u64
+import sys
+from dataclasses import dataclass
+from typing import List
+from py2many.spec import CHECKER
+from py2many.theorem import by, lemma, theorem
+
+
+@dataclass
+class BankAccount:
+    balance: int
+
+    def deposit(self, amount: int) -> "BankAccount":
+        return BankAccount(self.balance + amount)
+
+
+def safe_sqrt(n: int) -> int:
+    i: int = 0
+    while i * i <= n:
+        i += 1
+    return i - 1
+
+
+@lemma
+@by("native_decide")
+def sqrt_of_9() -> bool:
+    return safe_sqrt(9) == 3
+
+
+def merge(left: List[int], right: List[int]) -> List[int]:
+    result: List[int] = []
+    i: int = 0
+    j: int = 0
+    while i < len(left) and j < len(right):
+        if left[i] <= right[j]:
+            result.append(left[i])
+            i += 1
+        else:
+            result.append(right[j])
+            j += 1
+    while i < len(left):
+        result.append(left[i])
+        i += 1
+    while j < len(right):
+        result.append(right[j])
+        j += 1
+    return result
+
+
+def take(xs: List[int], n: int) -> List[int]:
+    out: List[int] = []
+    i: int = 0
+    while i < n:
+        out.append(xs[i])
+        i += 1
+    return out
+
+
+def drop(xs: List[int], n: int) -> List[int]:
+    out: List[int] = []
+    i: int = n
+    while i < len(xs):
+        out.append(xs[i])
+        i += 1
+    return out
+
+
+def sort_u64(arr: List[int]) -> List[int]:
+    if len(arr) <= 1:
+        return arr
+    mid: int = len(arr) // 2
+    left: List[int] = sort_u64(take(arr, mid))
+    right: List[int] = sort_u64(drop(arr, mid))
+    return merge(left, right)
+
+
+@by("native_decide")
+@theorem
+def concrete_example() -> bool:
+    return sort_u64([3, 1, 4, 1, 5, 9, 2, 6]) == [1, 1, 2, 3, 4, 5, 6, 9]
+
+
+if __name__ == "__main__":
+    acct: BankAccount = BankAccount(10)
+    print("OK")


### PR DESCRIPTION
Fixes: #805 

## Overview

Write a merge sort in Python, transpile it to **Lean** (for formal verification)
and **Rust** (for native execution) from the same source.  Lean proves
correctness via `lake build`; Rust runs the unverified algorithm natively.

```
                   ┌─── py2many --lean ──▶  .lean  ──▶  lake build ──▶ yes/no
verified_sort.py───┤
                   └─── py2many --rust ──▶  .rs    ──▶  cargo run  ──▶ output
```

| Target | Role | Signal |
|--------|------|--------|
| Lean   | **Verification** — theorems proved by `native_decide` | `lake build` exit 0 = proved |
| Rust   | **Execution** — run the sort at full speed | `cargo run` exit 0 = correct for test input |