### PR TITLE
CI: add lean focus option and install lean toolchain

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ on:
         - go
         - julia
         - kotlin
+        - lean
         - nim
         - smt
         - vlang
@@ -211,6 +212,24 @@ jobs:
         run: |
           rustup default stable
           rustup component add clippy rustfmt
+
+      - name: Install lean toolchain
+        if: ${{ env.FOCUS != 'omni' && (!env.FOCUS || env.FOCUS == 'lean') }}
+        shell: bash
+        run: |
+          # Lean 4 ships standalone per-platform toolchain archives
+          # (bin/lean, bin/lake, ...), so install directly. Keep the version in
+          # sync with .mise/config.lean.toml ("http:lean").
+          LEAN_VERSION=4.30.0
+          curl -fsSL -o /tmp/lean.zip \
+            "https://github.com/leanprover/lean4/releases/download/v${LEAN_VERSION}/lean-${LEAN_VERSION}-linux.zip"
+          unzip -q /tmp/lean.zip -d /opt
+          rm -f /tmp/lean.zip
+          # Make lean/lake available to the Run tox step; also verify now.
+          echo "/opt/lean-${LEAN_VERSION}-linux/bin" >> "$GITHUB_PATH"
+          export PATH="/opt/lean-${LEAN_VERSION}-linux/bin:${PATH}"
+          lean --version
+          lake --version
 
       - name: Run tox
         shell: bash

--- a/docker/Dockerfile.omni
+++ b/docker/Dockerfile.omni
@@ -96,8 +96,8 @@ RUN arch="$(dpkg --print-architecture)" \
     && nim --version \
     && curl -fsSL -o /tmp/lean.zip \
       "https://github.com/leanprover/lean4/releases/download/v${LEAN_VERSION}/${lean_archive}.zip" \
-    && mkdir -p /opt/lean \
-    && unzip -q /tmp/lean.zip -d /opt/lean --strip-components=1 \
+    && unzip -q /tmp/lean.zip -d /opt \
+    && mv "/opt/${lean_archive}" /opt/lean \
     && rm /tmp/lean.zip \
     && lean --version \
     && lake --version

--- a/docker/Dockerfile.omni
+++ b/docker/Dockerfile.omni
@@ -12,11 +12,12 @@ ARG FLUTTER_VERSION=3.22.3
 ARG GO_VERSION=1.26.0
 ARG JULIA_VERSION=1.10.5
 ARG KOTLIN_VERSION=1.7.20
+ARG LEAN_VERSION=4.30.0
 ARG NIM_VERSION=2.0.8
 ARG ZIG_VERSION=0.14.0
 
 ENV HOME=/root \
-    PATH="/root/.venv/bin:/root/.juliaup/bin:/root/go/bin:/usr/local/go/bin:/root/.cargo/bin:/root/.pub-cache/bin:/opt/v:/opt/flutter/bin:/opt/dart-sdk/bin:/opt/julia/bin:/opt/kotlinc/bin:/opt/zig:${PATH}" \
+    PATH="/root/.venv/bin:/root/.juliaup/bin:/root/go/bin:/usr/local/go/bin:/root/.cargo/bin:/root/.pub-cache/bin:/opt/v:/opt/flutter/bin:/opt/dart-sdk/bin:/opt/julia/bin:/opt/kotlinc/bin:/opt/lean/bin:/opt/zig:${PATH}" \
     CXX=clang++ \
     CXXFLAGS="-fuse-ld=lld" \
     CLANG_FORMAT_STYLE=Google \
@@ -65,8 +66,8 @@ RUN apt-get update \
 
 RUN arch="$(dpkg --print-architecture)" \
     && case "${arch}" in \
-      amd64) go_arch="amd64"; zig_arch="x86_64"; julia_path_arch="x64"; julia_tar_arch="x86_64"; nim_arch="x64" ;; \
-      arm64) go_arch="arm64"; zig_arch="aarch64"; julia_path_arch="aarch64"; julia_tar_arch="aarch64"; nim_arch="arm64" ;; \
+      amd64) go_arch="amd64"; zig_arch="x86_64"; julia_path_arch="x64"; julia_tar_arch="x86_64"; nim_arch="x64"; lean_archive="lean-${LEAN_VERSION}-linux" ;; \
+      arm64) go_arch="arm64"; zig_arch="aarch64"; julia_path_arch="aarch64"; julia_tar_arch="aarch64"; nim_arch="arm64"; lean_archive="lean-${LEAN_VERSION}-linux_aarch64" ;; \
       *) echo "Unsupported release target: ${arch}" >&2; exit 1 ;; \
     esac \
     && curl -fsSL -o /tmp/go.tar.gz "https://go.dev/dl/go${GO_VERSION}.linux-${go_arch}.tar.gz" \
@@ -92,7 +93,14 @@ RUN arch="$(dpkg --print-architecture)" \
     && rm /tmp/nim.tar.xz \
     && ln -sf /opt/nim/bin/nim /usr/local/bin/nim \
     && ln -sf /opt/nim/bin/nimpretty /usr/local/bin/nimpretty \
-    && nim --version
+    && nim --version \
+    && curl -fsSL -o /tmp/lean.zip \
+      "https://github.com/leanprover/lean4/releases/download/v${LEAN_VERSION}/${lean_archive}.zip" \
+    && mkdir -p /opt/lean \
+    && unzip -q /tmp/lean.zip -d /opt/lean --strip-components=1 \
+    && rm /tmp/lean.zip \
+    && lean --version \
+    && lake --version
 
 RUN python3 -m venv "${HOME}/.venv" \
     && source "${HOME}/.venv/bin/activate" \


### PR DESCRIPTION
Adds `lean` to the workflow_dispatch focus dropdown in main.yml and a step that installs the Lean 4 toolchain (lean/lake) directly from the official release archive, keeping the version in sync with `.mise/config.lean.toml` (4.30.0).

The step mirrors the other per-language install steps: it runs for the `lean` focus and the default all-languages run, and is skipped for omni (whose image lacks lean, so those cases skip gracefully).

Tested via a CI run with focus = lean.