### PR TITLE
CI: upload test results even when regeneration tests fail

### DIFF
--- a/.github/workflows/update_existing.yml
+++ b/.github/workflows/update_existing.yml
@@ -123,6 +123,7 @@ jobs:
           tox -v -- --cov-fail-under=0 2>&1 | tee tests/tox.log
 
       - name: Collect updated and new expected outputs
+        if: always()
         shell: bash
         run: |
           set -ex
@@ -144,6 +145,7 @@ jobs:
           cat update_output/README.txt
 
       - name: Upload updated expected outputs
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: updated-expected-${{ matrix.python-version }}
@@ -157,6 +159,7 @@ jobs:
           files: "tests/current-results.xml"
 
       - name: Archive test results
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: junit-xml-results


### PR DESCRIPTION
Fixes the Update Expected workflow so a fixture regression doesn't hide the results.

The `Collect updated and new expected outputs`, `Upload updated expected outputs`, and `Archive test results` steps had no `if:`, so they defaulted to `if: success()`. When the `UPDATE_EXPECTED` tox run had test failures, all three were skipped and nothing was uploaded. Now they run `if: always()`, so the junit results and any partially regenerated expected outputs are always captured regardless of test outcome.